### PR TITLE
Implement HashiCorp Vault integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ setup.py
 poetry.lock
 Pipfile.lock
 .vscode/settings.json
+.coverage

--- a/Pipfile
+++ b/Pipfile
@@ -5,8 +5,12 @@ verify_ssl = true
 
 [dev-packages]
 pytest = "*"
+pytest-mock = "*"
+coverage = "*"
+pytest-cov = "*"
 
 [packages]
 cryptography = "==44.0.1"
 fire = "==0.1.3"
 pyyaml = "*"
+hvac = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c6b30e22491d36098a4f425fec63da5758851cf150f5177abc69d97ef94f578d"
+            "sha256": "3c405bd6f12deee19d2411a41983eba6847e25e84d8afb45c5287cf1501ed2c7"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,14 @@
         ]
     },
     "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6",
+                "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2025.4.26"
+        },
         "cffi": {
             "hashes": [
                 "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8",
@@ -84,8 +92,106 @@
                 "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87",
                 "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "platform_python_implementation != 'PyPy'",
             "version": "==1.17.1"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4",
+                "sha256:046595208aae0120559a67693ecc65dd75d46f7bf687f159127046628178dc45",
+                "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7",
+                "sha256:0c8c57f84ccfc871a48a47321cfa49ae1df56cd1d965a09abe84066f6853b9c0",
+                "sha256:0f5d9ed7f254402c9e7d35d2f5972c9bbea9040e99cd2861bd77dc68263277c7",
+                "sha256:18dd2e350387c87dabe711b86f83c9c78af772c748904d372ade190b5c7c9d4d",
+                "sha256:1b1bde144d98e446b056ef98e59c256e9294f6b74d7af6846bf5ffdafd687a7d",
+                "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0",
+                "sha256:1cad5f45b3146325bb38d6855642f6fd609c3f7cad4dbaf75549bf3b904d3184",
+                "sha256:21b2899062867b0e1fde9b724f8aecb1af14f2778d69aacd1a5a1853a597a5db",
+                "sha256:24498ba8ed6c2e0b56d4acbf83f2d989720a93b41d712ebd4f4979660db4417b",
+                "sha256:25a23ea5c7edc53e0f29bae2c44fcb5a1aa10591aae107f2a2b2583a9c5cbc64",
+                "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b",
+                "sha256:28a1005facc94196e1fb3e82a3d442a9d9110b8434fc1ded7a24a2983c9888d8",
+                "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff",
+                "sha256:36b31da18b8890a76ec181c3cf44326bf2c48e36d393ca1b72b3f484113ea344",
+                "sha256:3c21d4fca343c805a52c0c78edc01e3477f6dd1ad7c47653241cf2a206d4fc58",
+                "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e",
+                "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471",
+                "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148",
+                "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a",
+                "sha256:50bf98d5e563b83cc29471fa114366e6806bc06bc7a25fd59641e41445327836",
+                "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e",
+                "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63",
+                "sha256:5bf4545e3b962767e5c06fe1738f951f77d27967cb2caa64c28be7c4563e162c",
+                "sha256:6333b3aa5a12c26b2a4d4e7335a28f1475e0e5e17d69d55141ee3cab736f66d1",
+                "sha256:65c981bdbd3f57670af8b59777cbfae75364b483fa8a9f420f08094531d54a01",
+                "sha256:68a328e5f55ec37c57f19ebb1fdc56a248db2e3e9ad769919a58672958e8f366",
+                "sha256:6a0289e4589e8bdfef02a80478f1dfcb14f0ab696b5a00e1f4b8a14a307a3c58",
+                "sha256:6b66f92b17849b85cad91259efc341dce9c1af48e2173bf38a85c6329f1033e5",
+                "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c",
+                "sha256:6fc1f5b51fa4cecaa18f2bd7a003f3dd039dd615cd69a2afd6d3b19aed6775f2",
+                "sha256:70f7172939fdf8790425ba31915bfbe8335030f05b9913d7ae00a87d4395620a",
+                "sha256:721c76e84fe669be19c5791da68232ca2e05ba5185575086e384352e2c309597",
+                "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b",
+                "sha256:75d10d37a47afee94919c4fab4c22b9bc2a8bf7d4f46f87363bcf0573f3ff4f5",
+                "sha256:76af085e67e56c8816c3ccf256ebd136def2ed9654525348cfa744b6802b69eb",
+                "sha256:770cab594ecf99ae64c236bc9ee3439c3f46be49796e265ce0cc8bc17b10294f",
+                "sha256:7a6ab32f7210554a96cd9e33abe3ddd86732beeafc7a28e9955cdf22ffadbab0",
+                "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941",
+                "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0",
+                "sha256:8075c35cd58273fee266c58c0c9b670947c19df5fb98e7b66710e04ad4e9ff86",
+                "sha256:8272b73e1c5603666618805fe821edba66892e2870058c94c53147602eab29c7",
+                "sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7",
+                "sha256:844da2b5728b5ce0e32d863af26f32b5ce61bc4273a9c720a9f3aa9df73b1455",
+                "sha256:8755483f3c00d6c9a77f490c17e6ab0c8729e39e6390328e42521ef175380ae6",
+                "sha256:915f3849a011c1f593ab99092f3cecfcb4d65d8feb4a64cf1bf2d22074dc0ec4",
+                "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0",
+                "sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3",
+                "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1",
+                "sha256:9cbfacf36cb0ec2897ce0ebc5d08ca44213af24265bd56eca54bee7923c48fd6",
+                "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981",
+                "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c",
+                "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980",
+                "sha256:aa88ca0b1932e93f2d961bf3addbb2db902198dca337d88c89e1559e066e7645",
+                "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7",
+                "sha256:aaf27faa992bfee0264dc1f03f4c75e9fcdda66a519db6b957a3f826e285cf12",
+                "sha256:b2680962a4848b3c4f155dc2ee64505a9c57186d0d56b43123b17ca3de18f0fa",
+                "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd",
+                "sha256:b33de11b92e9f75a2b545d6e9b6f37e398d86c3e9e9653c4864eb7e89c5773ef",
+                "sha256:b3daeac64d5b371dea99714f08ffc2c208522ec6b06fbc7866a450dd446f5c0f",
+                "sha256:be1e352acbe3c78727a16a455126d9ff83ea2dfdcbc83148d2982305a04714c2",
+                "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d",
+                "sha256:c72fbbe68c6f32f251bdc08b8611c7b3060612236e960ef848e0a517ddbe76c5",
+                "sha256:c9e36a97bee9b86ef9a1cf7bb96747eb7a15c2f22bdb5b516434b00f2a599f02",
+                "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3",
+                "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd",
+                "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e",
+                "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214",
+                "sha256:d524ba3f1581b35c03cb42beebab4a13e6cdad7b36246bd22541fa585a56cccd",
+                "sha256:daac4765328a919a805fa5e2720f3e94767abd632ae410a9062dff5412bae65a",
+                "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c",
+                "sha256:dc7039885fa1baf9be153a0626e337aa7ec8bf96b0128605fb0d77788ddc1681",
+                "sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba",
+                "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f",
+                "sha256:e45ba65510e2647721e35323d6ef54c7974959f6081b58d4ef5d87c60c84919a",
+                "sha256:e53efc7c7cee4c1e70661e2e112ca46a575f90ed9ae3fef200f2a25e954f4b28",
+                "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691",
+                "sha256:e70e990b2137b29dc5564715de1e12701815dacc1d056308e2b17e9095372a82",
+                "sha256:e8082b26888e2f8b36a042a58307d5b917ef2b1cacab921ad3323ef91901c71a",
+                "sha256:e8323a9b031aa0393768b87f04b4164a40037fb2a3c11ac06a03ffecd3618027",
+                "sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7",
+                "sha256:eb30abc20df9ab0814b5a2524f23d75dcf83cde762c161917a2b4b7b55b1e518",
+                "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf",
+                "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b",
+                "sha256:efd387a49825780ff861998cd959767800d54f8308936b21025326de4b5a42b9",
+                "sha256:f0aa37f3c979cf2546b73e8222bbfa3dc07a641585340179d768068e3455e544",
+                "sha256:f4074c5a429281bf056ddd4c5d3b740ebca4d43ffffe2ef4bf4d2d05114299da",
+                "sha256:f69a27e45c43520f5487f27627059b64aaf160415589230992cec34c5e18a509",
+                "sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f",
+                "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a",
+                "sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.2"
         },
         "cryptography": {
             "hashes": [
@@ -131,6 +237,23 @@
             ],
             "index": "pypi",
             "version": "==0.1.3"
+        },
+        "hvac": {
+            "hashes": [
+                "sha256:1b85e3320e8642dd82f234db63253cda169a817589e823713dc5fca83119b1e2",
+                "sha256:a3afc5710760b6ee9b3571769df87a0333da45da05a5f9f963e1d3925a84be7d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==2.3.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.10"
         },
         "pycparser": {
             "hashes": [
@@ -200,6 +323,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.0.2"
         },
+        "requests": {
+            "hashes": [
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.3"
+        },
         "six": {
             "hashes": [
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
@@ -207,16 +338,97 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.17.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
+                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.4.0"
         }
     },
     "develop": {
+        "coverage": {
+            "extras": [
+                "toml"
+            ],
+            "hashes": [
+                "sha256:042e7841a26498fff7a37d6fda770d17519982f5b7d8bf5278d140b67b61095f",
+                "sha256:04bfec25a8ef1c5f41f5e7e5c842f6b615599ca8ba8391ec33a9290d9d2db3a3",
+                "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05",
+                "sha256:18c5ae6d061ad5b3e7eef4363fb27a0576012a7447af48be6c75b88494c6cf25",
+                "sha256:2931f66991175369859b5fd58529cd4b73582461877ecfd859b6549869287ffe",
+                "sha256:2e4b6b87bb0c846a9315e3ab4be2d52fac905100565f4b92f02c445c8799e257",
+                "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78",
+                "sha256:379fe315e206b14e21db5240f89dc0774bdd3e25c3c58c2c733c99eca96f1ada",
+                "sha256:42421e04069fb2cbcbca5a696c4050b84a43b05392679d4068acbe65449b5c64",
+                "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6",
+                "sha256:52a523153c568d2c0ef8826f6cc23031dc86cffb8c6aeab92c4ff776e7951b28",
+                "sha256:554fec1199d93ab30adaa751db68acec2b41c5602ac944bb19187cb9a41a8067",
+                "sha256:581a40c7b94921fffd6457ffe532259813fc68eb2bdda60fa8cc343414ce3733",
+                "sha256:5a26c0c795c3e0b63ec7da6efded5f0bc856d7c0b24b2ac84b4d1d7bc578d676",
+                "sha256:5a570cd9bd20b85d1a0d7b009aaf6c110b52b5755c17be6962f8ccd65d1dbd23",
+                "sha256:5aaeb00761f985007b38cf463b1d160a14a22c34eb3f6a39d9ad6fc27cb73008",
+                "sha256:5ac46d0c2dd5820ce93943a501ac5f6548ea81594777ca585bf002aa8854cacd",
+                "sha256:5c8a5c139aae4c35cbd7cadca1df02ea8cf28a911534fc1b0456acb0b14234f3",
+                "sha256:6b8af63b9afa1031c0ef05b217faa598f3069148eeee6bb24b79da9012423b82",
+                "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545",
+                "sha256:771eb7587a0563ca5bb6f622b9ed7f9d07bd08900f7589b4febff05f469bea00",
+                "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47",
+                "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501",
+                "sha256:821f7bcbaa84318287115d54becb1915eece6918136c6f91045bb84e2f88739d",
+                "sha256:89b1f4af0d4afe495cd4787a68e00f30f1d15939f550e869de90a86efa7e0814",
+                "sha256:8a1d96e780bdb2d0cbb297325711701f7c0b6f89199a57f2049e90064c29f6bd",
+                "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a",
+                "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318",
+                "sha256:90e7fbc6216ecaffa5a880cdc9c77b7418c1dcb166166b78dbc630d07f278cc3",
+                "sha256:94ec0be97723ae72d63d3aa41961a0b9a6f5a53ff599813c324548d18e3b9e8c",
+                "sha256:95aa6ae391a22bbbce1b77ddac846c98c5473de0372ba5c463480043a07bff42",
+                "sha256:96121edfa4c2dfdda409877ea8608dd01de816a4dc4a0523356067b305e4e17a",
+                "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6",
+                "sha256:a321c61477ff8ee705b8a5fed370b5710c56b3a52d17b983d9215861e37b642a",
+                "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7",
+                "sha256:a9abbccd778d98e9c7e85038e35e91e67f5b520776781d9a1e2ee9d400869487",
+                "sha256:ad80e6b4a0c3cb6f10f29ae4c60e991f424e6b14219d46f1e7d442b938ee68a4",
+                "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2",
+                "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9",
+                "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd",
+                "sha256:b87eb6fc9e1bb8f98892a2458781348fa37e6925f35bb6ceb9d4afd54ba36c73",
+                "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc",
+                "sha256:be945402e03de47ba1872cd5236395e0f4ad635526185a930735f66710e1bd3f",
+                "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea",
+                "sha256:cf60dd2696b457b710dd40bf17ad269d5f5457b96442f7f85722bdb16fa6c899",
+                "sha256:d1ba00ae33be84066cfbe7361d4e04dec78445b2b88bdb734d0d1cbab916025a",
+                "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543",
+                "sha256:d766a4f0e5aa1ba056ec3496243150698dc0481902e2b8559314368717be82b1",
+                "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7",
+                "sha256:dd19608788b50eed889e13a5d71d832edc34fc9dfce606f66e8f9f917eef910d",
+                "sha256:e013b07ba1c748dacc2a80e69a46286ff145935f260eb8c72df7185bf048f502",
+                "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b",
+                "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040",
+                "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c",
+                "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27",
+                "sha256:ed2144b8a78f9d94d9515963ed273d620e07846acd5d4b0a642d4849e8d91a0c",
+                "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d",
+                "sha256:f1d8a2a57b47142b10374902777e798784abf400a004b14f1b0b9eaf1e528ba4",
+                "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe",
+                "sha256:f319bae0321bc838e205bf9e5bc28f0a3165f30c203b610f17ab5552cff90323",
+                "sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883",
+                "sha256:f9983d01d7705b2d1f7a95e10bbe4091fabc03a46881a256c2787637b087003f",
+                "sha256:fa260de59dfb143af06dcf30c2be0b200bed2a73737a8a59248fcb9fa601ef0f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==7.8.0"
+        },
         "exceptiongroup": {
             "hashes": [
-                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
-                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+                "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10",
+                "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.2.2"
+            "version": "==1.3.0"
         },
         "iniconfig": {
             "hashes": [
@@ -250,6 +462,24 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==8.3.5"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a",
+                "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==6.1.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f",
+                "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.14.0"
         },
         "tomli": {
             "hashes": [
@@ -288,6 +518,14 @@
             ],
             "markers": "python_version < '3.11'",
             "version": "==2.2.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
+                "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"
+            ],
+            "markers": "python_version < '3.13'",
+            "version": "==4.13.2"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,24 +1,32 @@
 # Keylocker CLI (YAML Edition)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/keylocker)](https://pypi.org/project/keylocker/) [![Downloads](https://static.pepy.tech/badge/keylocker)](https://pepy.tech/project/keylocker)
 
-A command-line interface (CLI) tool and Python library for managing secrets directly within YAML configuration files. Allows encrypting individual values using the `!SEC` tag and loading values from environment variables using the `!ENV` tag.
+A command-line interface (CLI) tool and Python library for managing secrets directly within YAML configuration files. Allows encrypting individual values using the `!SEC` tag, loading values from environment variables using the `!ENV` tag, and fetching secrets from HashiCorp Vault using the `!VAULT` tag.
 
 * Wiki: [https://deepwiki.com/vpuhoff/keylocker](https://deepwiki.com/vpuhoff/keylocker/1-overview)
 
 ![Alt](https://repobeats.axiom.co/api/embed/61e3a712de309936dc034c3851dc1a6144d3b4dd.svg "Repobeats analytics image")
 
-## Encryption Key
+## Encryption Key (Fernet)
 
-Keylocker uses a Fernet key for encryption and decryption. The key is obtained in the following order of priority:
+Keylocker uses a Fernet key for encrypting and decrypting `!SEC` tags. The key is obtained in the following order of priority:
 
-1.  **`KEYLOCKER_SECRET_KEY` Environment Variable:** If this environment variable is set, its value is used directly as the Fernet key (it should be a valid base64 encoded key).
-2.  **`storage.key` File:** If the environment variable is not set, Keylocker attempts to read the key from the `storage.key` file in the current directory by default.
+1.  **`KEYLOCKER_SECRET_KEY` Environment Variable**: If this environment variable is set, its value is used directly as the Fernet key (it should be a valid base64 encoded key string).
+2.  **`storage.key` File**: If the environment variable is not set, Keylocker attempts to read the key from the `storage.key` file in the current directory by default.
 
-Use the `keylocker init` command to generate a `storage.key` file if you prefer file-based key storage. Note that if `KEYLOCKER_SECRET_KEY` is set, it will always take precedence over the file for encryption/decryption operations.
+Use the `keylocker init` command to generate a `storage.key` file if you prefer file-based key storage. Note that if `KEYLOCKER_SECRET_KEY` is set, it will always take precedence over the file for `!SEC` encryption/decryption operations.
+
+## HashiCorp Vault Configuration
+
+To use the `!VAULT` tag, you need to configure access to your HashiCorp Vault instance via the following environment variables:
+* **`VAULT_ADDR`**: The URL of your Vault instance (e.g., `http://127.0.0.1:8200`).
+* **`VAULT_TOKEN`**: The token for authenticating with Vault. (Other authentication methods may be added in the future).
+
+If these variables are not set, attempting to use a `!VAULT` tag will result in an error.
 
 ## Installation
 
-You can install the package using pip:
+You can install the package using pip. The `hvac` library will also be installed as a dependency for Vault support.
 
 ```bash
 pip install keylocker
@@ -34,39 +42,47 @@ database:
   host: db.example.com
   username: user
   # Encrypted password using 'keylocker encrypt'
-  password: !SEC gAAAAABh...[rest of encrypted data]...
+  password: !SEC gAAAAABh...[rest_of_encrypted_data]...
 api:
-  endpoint: [https://api.example.com](https://api.example.com)
+  endpoint: https://api.example.com
   # Load key from the API_KEY environment variable
   key: !ENV API_KEY
 deployment:
   region: us-east-1
-  # Another secret
-  ssh_key_pass: !SEC gAAAAABh...[another encrypted data]...
+  # Secret from HashiCorp Vault (e.g., KV v2)
+  # Path: 'your_kv_mount/data/path/to/secret', Key in secret: 'secret_key_name'
+  vault_secret: !VAULT your_kv_mount/data/path/to/secret:secret_key_name
+  # Another encrypted secret
+  ssh_key_pass: !SEC gAAAAABh...[another_encrypted_data]...
 ```
 
 ## CLI Usage:
 
-1.  **Initialization (create key file):**
+1.  **Initialization (create Fernet key file):**
     * Generates the `storage.key` file (if it doesn't exist). This file is used *only* if the `KEYLOCKER_SECRET_KEY` environment variable is *not* set.
     ```bash
     keylocker init [--force]
     ```
 
 2.  **Encrypt value for YAML:**
-    * Encrypts a string using the available key (Environment Variable or Key File) and prints the `!SEC` tag for you to copy into your YAML file.
+    * Encrypts a string using the available Fernet key (from Environment Variable or Key File) and prints the `!SEC` tag for you to copy into your YAML file.
     ```bash
     keylocker encrypt "my_secret_value"
     # Output:
     # Add the following line to your YAML file:
-    # !SEC gAAAAABh...[encrypted data]...
+    # !SEC gAAAAABh...[encrypted_data]...
     ```
 
 3.  **View decrypted YAML:**
-    * Loads the specified YAML file, resolves `!ENV` variables, decrypts `!SEC` values using the available key (Environment Variable or Key File), and prints the resulting YAML to standard output.
+    * Loads the specified YAML file, resolves `!ENV` variables, decrypts `!SEC` values (using the Fernet key), and fetches `!VAULT` secrets (using Vault configuration), then prints the resulting YAML to standard output.
     ```bash
     # Set environment variables if your YAML uses !ENV
     export API_KEY="your_actual_api_key"
+    # Set variables for Vault if your YAML uses !VAULT
+    export VAULT_ADDR="http://127.0.0.1:8200"
+    export VAULT_TOKEN="your_vault_token"
+    # Set KEYLOCKER_SECRET_KEY if using it for !SEC
+    # export KEYLOCKER_SECRET_KEY='your_base64_fernet_key'
 
     keylocker view config.yaml
     # Example output (values resolved/decrypted):
@@ -75,10 +91,11 @@ deployment:
     #   username: user
     #   password: my_secret_value
     # api:
-    #   endpoint: [https://api.example.com](https://api.example.com)
+    #   endpoint: https://api.example.com
     #   key: your_actual_api_key
     # deployment:
     #   region: us-east-1
+    #   vault_secret: value_from_vault
     #   ssh_key_pass: decrypted_pass
     ```
     *(Note: An `edit` command might be added in the future for interactive editing)*
@@ -87,31 +104,56 @@ deployment:
 
 ```python
 import os
-from keylocker import load_yaml_secrets
+import yaml # For yaml.YAMLError
+from keylocker import (
+    load_yaml_secrets,
+    KeylockerError, # Base keylocker error class
+    KeylockerFileError,
+    KeylockerEncryptionError,
+    KeylockerVaultError
+    # ... and other specific exceptions if you need to catch them separately
+)
 
 # Set environment variables if your YAML uses !ENV
 os.environ['API_KEY'] = 'your_actual_api_key_for_python'
-# Set KEYLOCKER_SECRET_KEY if using env var for the encryption key
+
+# Set variables for Vault if your YAML uses !VAULT
+os.environ['VAULT_ADDR'] = 'http://127.0.0.1:8200' # Example
+os.environ['VAULT_TOKEN'] = 'your_python_vault_token'
+
+# Set KEYLOCKER_SECRET_KEY if using it for the !SEC encryption key
 # os.environ['KEYLOCKER_SECRET_KEY'] = 'your_base64_encoded_fernet_key'
+# Alternatively, ensure 'storage.key' exists if KEYLOCKER_SECRET_KEY is not set
 
 config_file = 'config.yaml'
-# The key_file parameter acts as a fallback if KEYLOCKER_SECRET_KEY is not set
-key_file_path = 'storage.key'
+# The key_file_path parameter is used if KEYLOCKER_SECRET_KEY is not set
+key_file_path = 'storage.key' # Default path
 
 try:
-    # Load, resolve !ENV, and decrypt !SEC automatically
-    secrets = load_yaml_secrets(config_file, key_file_path)
+    # Automatically load, resolve !ENV, !VAULT, and decrypt !SEC
+    secrets = load_yaml_secrets(config_file, key_file_path=key_file_path)
 
     if secrets:
         db_password = secrets.get('database', {}).get('password')
-        api_key = secrets.get('api', {}).get('key')
+        api_key_from_env = secrets.get('api', {}).get('key')
+        vault_secret_value = secrets.get('deployment', {}).get('vault_secret')
 
         print(f"Database Password (from Python): {db_password}")
-        print(f"API Key (from Python): {api_key}")
+        print(f"API Key (from Python): {api_key_from_env}")
+        print(f"Vault Secret (from Python): {vault_secret_value}")
 
-except Exception as e:
-    print(f"An error occurred: {e}")
-
+except KeylockerFileError as e:
+    print(f"File error: {e}")
+except KeylockerEncryptionError as e:
+    print(f"Encryption/Decryption error: {e}")
+except KeylockerVaultError as e:
+    print(f"Vault error: {e}")
+except KeylockerError as e: # General keylocker error
+    print(f"Keylocker processing error: {e}")
+except yaml.YAMLError as e:
+    print(f"YAML parsing error: {e}")
+except Exception as e: # Any other unexpected errors
+    print(f"An unexpected error occurred: {type(e).__name__} - {e}")
 ```
 
 ## Usage in Bash:
@@ -123,36 +165,50 @@ To extract specific values from the resolved/decrypted YAML for use in scripts.
 
 # Set environment variables if your YAML uses !ENV
 export API_KEY="your_bash_api_key"
-# Set KEYLOCKER_SECRET_KEY if using env var for the encryption key
+
+# Set variables for Vault if your YAML uses !VAULT
+export VAULT_ADDR="http://127.0.0.1:8200"
+export VAULT_TOKEN="your_bash_vault_token"
+
+# Set KEYLOCKER_SECRET_KEY if using it for the !SEC encryption key
 # export KEYLOCKER_SECRET_KEY='your_base64_encoded_fernet_key'
 
 # Get the decrypted YAML content
-CONFIG_YAML=$(keylocker view config.yaml)
+# Redirect stderr to /dev/null if you don't want to see keylocker's INFO/WARNING messages
+CONFIG_YAML=$(keylocker view config.yaml 2>/dev/null)
 
 # Check if the command executed successfully
 if [ $? -ne 0 ]; then
-  echo "Error executing keylocker view"
+  echo "Error executing keylocker view. Check stderr for details from keylocker."
+  # To see errors from keylocker if any, run without 2>/dev/null
+  # keylocker view config.yaml
   exit 1
 fi
 
 # Example extraction using yq (requires yq installation)
 # DB_PASS=$(echo "$CONFIG_YAML" | yq e '.database.password' -)
 # API_KEY_FROM_YAML=$(echo "$CONFIG_YAML" | yq e '.api.key' -)
+# VAULT_SECRET_FROM_YAML=$(echo "$CONFIG_YAML" | yq e '.deployment.vault_secret' -)
 
-# Example extraction using grep/awk (less robust)
-DB_PASS=$(echo "$CONFIG_YAML" | grep -A 1 'database:' | grep 'password:' | awk '{print $2}')
-API_KEY_FROM_YAML=$(echo "$CONFIG_YAML" | grep -A 1 'api:' | grep 'key:' | awk '{print $2}')
+
+# Example extraction using grep/awk (less robust, sensitive to formatting)
+# This method may not work correctly for multi-line or complex values.
+DB_PASS=$(echo "$CONFIG_YAML" | grep -A 2 'database:' | grep 'password:' | awk '{print $NF}')
+API_KEY_FROM_YAML=$(echo "$CONFIG_YAML" | grep -A 2 'api:' | grep 'key:' | awk '{print $NF}')
+VAULT_SECRET_FROM_YAML=$(echo "$CONFIG_YAML" | grep -A 2 'deployment:' | grep 'vault_secret:' | awk '{print $NF}')
 
 
 echo "Extracted DB Password (from Bash): $DB_PASS"
 echo "Extracted API Key (from Bash): $API_KEY_FROM_YAML"
+echo "Extracted Vault Secret (from Bash): $VAULT_SECRET_FROM_YAML"
 
 # Further use of variables in your script
 # e.g., ./deploy_script.sh --db-password "$DB_PASS" --api-key "$API_KEY_FROM_YAML"
 ```
 
 ## Source Code:
-* [https://github.com/vpuhoff/keylocker](https://github.com/vpuhoff/keylocker)
-* [https://deepwiki.com/vpuhoff/keylocker](https://deepwiki.com/vpuhoff/keylocker/1-overview)
 
-```
+  * [https://github.com/vpuhoff/keylocker](https://github.com/vpuhoff/keylocker)
+  * [https://deepwiki.com/vpuhoff/keylocker](https://deepwiki.com/vpuhoff/keylocker/1-overview)
+
+-----

--- a/keylocker/__init__.py
+++ b/keylocker/__init__.py
@@ -3,277 +3,418 @@
 import os
 import sys
 import base64
-import yaml # Added
+import yaml
 import fire
+import hvac
+import hvac.exceptions
+
 from cryptography.fernet import Fernet, InvalidToken
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 # --- Configuration ---
 DEFAULT_KEY_FILE = 'storage.key'
-ENV_VAR_NAME = 'KEYLOCKER_SECRET_KEY' # Environment variable for the key
+ENV_VAR_NAME = 'KEYLOCKER_SECRET_KEY'
 
-# --- Helper Function for Key Loading ---
+VAULT_ADDR_ENV_VAR = 'VAULT_ADDR'
+VAULT_TOKEN_ENV_VAR = 'VAULT_TOKEN'
 
-def _load_fernet_key(key_file=DEFAULT_KEY_FILE):
+# --- Custom Exceptions ---
+class KeylockerError(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+class KeylockerFileError(KeylockerError):
+    """Custom error for file-related issues in Keylocker."""
+    pass
+
+class KeylockerEncryptionError(KeylockerError):
+    """Base class for encryption/decryption related errors."""
+    pass
+
+class KeylockerConfigError(KeylockerError):
+    """For general configuration errors."""
+    pass
+
+class KeylockerVaultError(KeylockerError):
+    """Base class for Vault related errors."""
+    pass
+
+class VaultClientNotInitializedError(KeylockerVaultError):
+    """Raised when Vault client is not initialized or authentication fails."""
+    pass
+
+class VaultInvalidFormatError(KeylockerVaultError):
+    """Raised for invalid !VAULT tag format."""
+    pass
+
+class VaultSecretNotFoundError(KeylockerVaultError):
+    """Raised when a secret is not found in Vault or data is empty."""
+    pass
+
+class VaultKeyNotFoundError(KeylockerVaultError):
+    """Raised when a key is not found within a Vault secret."""
+    pass
+
+class VaultInvalidPathError(KeylockerVaultError): # Renamed from Keylocker specific to general Vault
+    """Raised for an invalid secret path in Vault, wraps hvac.exceptions.InvalidPath."""
+    pass
+
+class VaultPermissionError(KeylockerVaultError): # Renamed
+    """Raised when permission is denied for a Vault secret, wraps hvac.exceptions.Forbidden."""
+    pass
+
+class VaultGenericClientError(KeylockerVaultError): # Renamed
+    """Raised for other hvac.exceptions.VaultError during client operations."""
+    pass
+
+# --- Helper Function for Fernet Key Loading ---
+def _load_fernet_key(key_file_path=DEFAULT_KEY_FILE):
     """
     Loads the Fernet key, prioritizing the environment variable.
-    Returns the key as bytes or None on error.
+    Returns the key as bytes.
+    Raises KeylockerEncryptionError or KeylockerFileError on error.
     """
     key_from_env = os.environ.get(ENV_VAR_NAME)
 
     if key_from_env:
         print(f"INFO: Using encryption key from environment variable {ENV_VAR_NAME}.")
         try:
-            # Assume the key in the env var is the correct base64 encoded string
             key_bytes = key_from_env.encode('utf-8')
-            # Validate the key by attempting to initialize Fernet
-            Fernet(key_bytes)
+            Fernet(key_bytes) # Validate key format
             return key_bytes
-        except (InvalidToken, ValueError, TypeError):
-             print(f"ERROR: Invalid key format found in environment variable {ENV_VAR_NAME}.")
-             return None
-        except Exception as e:
-             print(f"ERROR: Unexpected error validating key from env var {ENV_VAR_NAME}: {e}")
-             return None
-
+        except (InvalidToken, ValueError, TypeError) as e:
+            raise KeylockerEncryptionError(
+                f"Invalid key format in environment variable {ENV_VAR_NAME}. Details: {e}"
+            ) from e
+        except Exception as e: # Should be rare
+            raise KeylockerEncryptionError(
+                f"Unexpected error validating Fernet key from env var {ENV_VAR_NAME}: {e}"
+            ) from e
     else:
-        # Environment variable not set, try the key file
-        # Suppress message if key file is the default and doesn't exist during certain operations
-        # print(f"INFO: Environment variable {ENV_VAR_NAME} not set. Trying key file '{key_file}'.")
-        if not os.path.exists(key_file):
-            # It's okay if the file doesn't exist initially for 'init' command,
-            # but other commands will fail later if no key is found.
-            # Errors will be handled by the calling functions if no key is ultimately loaded.
-            return None # Indicate no key found *from file*
+        if not os.path.exists(key_file_path):
+            # This is a common case if the key file is expected but not found.
+            # It's not an error if 'init' hasn't been run, but if a key is *needed*, it is.
+            raise KeylockerFileError(f"Fernet key file '{key_file_path}' not found and {ENV_VAR_NAME} is not set.")
         try:
-            with open(key_file, 'rb') as kf:
+            with open(key_file_path, 'rb') as kf:
                 key_bytes = kf.read()
-            # Validate the key from the file
-            Fernet(key_bytes)
+            Fernet(key_bytes) # Validate key format
             return key_bytes
-        except FileNotFoundError:
-             # Should not happen due to os.path.exists check, but included for safety
-             print(f"ERROR: Key file '{key_file}' not found.")
-             return None
-        except (InvalidToken, ValueError, TypeError):
-             print(f"ERROR: Invalid key format in file '{key_file}'.")
-             return None
+        except FileNotFoundError: # Should have been caught by os.path.exists, but defensive
+            raise KeylockerFileError(f"Fernet key file '{key_file_path}' could not be opened (not found).") from None
+        except (InvalidToken, ValueError, TypeError) as e:
+            raise KeylockerEncryptionError(f"Invalid key format in Fernet key file '{key_file_path}'. Details: {e}") from e
         except IOError as e:
-            print(f"ERROR: Could not read key file '{key_file}': {e}")
-            return None
-        except Exception as e:
-             print(f"ERROR: Unexpected error reading key file '{key_file}': {e}")
-             return None
+            raise KeylockerFileError(f"Could not read Fernet key file '{key_file_path}'. Details: {e}") from e
+        except Exception as e: # Should be rare
+            raise KeylockerEncryptionError(f"Unexpected error reading Fernet key file '{key_file_path}': {e}") from e
+
+# --- Helper Function for Vault Client ---
+def _get_vault_client():
+    """
+    Initializes and returns an authenticated HVAC client for HashiCorp Vault.
+    Raises VaultClientNotInitializedError if configuration is missing or authentication fails.
+    """
+    vault_addr = os.environ.get(VAULT_ADDR_ENV_VAR)
+    if not vault_addr:
+        # This is a configuration error if !VAULT tags are to be used.
+        # The vault_constructor will check if vault_hvac_client is None.
+        # Let's make this function always return a client or raise an error.
+        raise VaultClientNotInitializedError(
+            f"Vault address environment variable '{VAULT_ADDR_ENV_VAR}' not set."
+        )
+
+    try:
+        client = hvac.Client(url=vault_addr)
+        vault_token = os.environ.get(VAULT_TOKEN_ENV_VAR)
+
+        if not vault_token: # Assuming token auth for now
+            raise VaultClientNotInitializedError(
+                f"Vault token environment variable '{VAULT_TOKEN_ENV_VAR}' not set (token authentication assumed)."
+            )
+        client.token = vault_token
+
+        if client.is_authenticated():
+            print(f"INFO: Successfully authenticated to Vault at {vault_addr}.")
+            return client
+        else:
+            raise VaultClientNotInitializedError(
+                f"Failed to authenticate to Vault at {vault_addr} with the provided token. Check token and Vault policies."
+            )
+    except hvac.exceptions.VaultError as e: # Covers connection errors, etc.
+        raise VaultClientNotInitializedError(f"Vault client setup/connection error for {vault_addr}: {e}") from e
+    except Exception as e: # Other unexpected errors during client init
+        raise VaultClientNotInitializedError(f"Unexpected error initializing Vault client for {vault_addr}: {e}") from e
 
 # --- YAML Tag Handling ---
+class SecureString(str): pass
+class EnvVariable(str): pass
 
-# Custom class to represent secrets before saving (for the dumper)
-class SecureString(str):
-    pass
+def keylocker_loader(key_file_path=DEFAULT_KEY_FILE): # Renamed arg for clarity
+    """
+    Creates a YAML Loader that handles !SEC, !ENV, and !VAULT tags.
+    Raises exceptions from _load_fernet_key or _get_vault_client if setup fails.
+    """
+    fernet_cipher = None
+    try:
+        # Attempt to load Fernet key. If not found and !SEC is used, sec_constructor will fail.
+        # If key is invalid, _load_fernet_key will raise KeylockerEncryptionError.
+        loaded_fernet_key_bytes = _load_fernet_key(key_file_path)
+        fernet_cipher = Fernet(loaded_fernet_key_bytes)
+    except KeylockerFileError: # Fernet key file not found, and no env var
+        # This is not necessarily an error for the loader if no !SEC tags are present.
+        # sec_constructor will raise an error if fernet_cipher is None and a !SEC tag is encountered.
+        print(f"INFO: Fernet key file '{key_file_path}' not found and {ENV_VAR_NAME} not set. !SEC tags will fail if used.")
+        fernet_cipher = None
+    except KeylockerEncryptionError as e:
+        # Key was found but is invalid/unusable. This is a more severe config error.
+        raise KeylockerConfigError(f"Failed to initialize Fernet cipher due to key error: {e}. !SEC tags cannot be processed.") from e
 
-# Custom class to represent env vars before saving (for the dumper)
-class EnvVariable(str):
-    pass
-
-# Loader: Decrypt !SEC tags, Resolve !ENV tags
-def keylocker_loader(key_file=DEFAULT_KEY_FILE):
-    """Creates a YAML Loader that handles !SEC and !ENV tags."""
-    key_bytes = _load_fernet_key(key_file)
-    if not key_bytes:
-        # Error message is handled by _load_fernet_key or subsequent checks
-        # We need to proceed to allow yaml.load to potentially fail gracefully
-        # or let the calling function handle the None key case.
-        # Returning None here would prevent loading YAML even with no secrets.
-        print("WARNING: No encryption key loaded. !SEC tags cannot be decrypted.")
-        fernet = None # Set fernet to None if no key
-    else:
+    vault_hvac_client = None
+    # Пытаемся инициализировать клиент Vault, только если VAULT_ADDR установлен
+    if os.environ.get(VAULT_ADDR_ENV_VAR): # Проверяем, что переменная установлена и имеет значение
         try:
-            fernet = Fernet(key_bytes)
-        except Exception as e:
-            print(f"ERROR: Failed to initialize Fernet with the loaded key: {e}")
-            fernet = None # Treat as no key if init fails
+            vault_hvac_client = _get_vault_client()
+        except VaultClientNotInitializedError:
+            # Если _get_vault_client() не смог инициализировать/аутентифицировать клиент,
+            # позволяем этому исключению всплыть дальше.
+            # Сообщение об ошибке от _get_vault_client() будет более информативным.
+            raise
+    else:
+        # VAULT_ADDR не установлен. vault_hvac_client остается None.
+        # vault_constructor обработает это, если встретит тег !VAULT.
+        print(f"INFO: Environment variable '{VAULT_ADDR_ENV_VAR}' is not set. "
+              f"Vault client will not be initialized. !VAULT tags will fail if used.")
 
-    class KeylockerLoader(yaml.SafeLoader):
-        pass
+    class KeylockerLoader(yaml.SafeLoader): pass
 
     def sec_constructor(loader, node):
         value = loader.construct_scalar(node)
-        if fernet is None:
-            print(f"ERROR: Cannot decrypt !SEC value as no valid key is loaded.")
-            return f"DECRYPTION_ERROR[NoKey]"
+        if fernet_cipher is None:
+            raise KeylockerEncryptionError(
+                f"Cannot decrypt !SEC value: Fernet encryption cipher not available. "
+                f"Ensure key file '{key_file_path}' exists or {ENV_VAR_NAME} is set correctly."
+            )
         try:
-            decrypted_value = fernet.decrypt(value.encode()).decode()
-            return decrypted_value
+            return fernet_cipher.decrypt(value.encode()).decode()
         except InvalidToken:
-            print(f"ERROR: Failed to decrypt value tagged !SEC. Invalid token or key mismatch.")
-            return f"DECRYPTION_ERROR[InvalidToken]"
+            raise KeylockerEncryptionError(f"Failed to decrypt !SEC value: Invalid token or key mismatch (value: '{value[:15]}...').")
         except Exception as e:
-            print(f"ERROR: Unexpected error during !SEC decryption: {e}")
-            return f"DECRYPTION_ERROR[{type(e).__name__}]"
+            raise KeylockerEncryptionError(f"Unexpected error during !SEC decryption: {e}")
 
     def env_constructor(loader, node):
         var_name = loader.construct_scalar(node)
         value = os.environ.get(var_name)
         if value is None:
-            print(f"WARNING: Environment variable '{var_name}' (tagged !ENV) not found. Returning None.")
-        return value # Return the raw value from env or None
+            # Option: raise KeylockerConfigError(f"Environment variable '{var_name}' for !ENV tag not found.")
+            print(f"WARNING: Environment variable '{var_name}' (tagged !ENV) not found. Resolving to None.", file=sys.stderr)
+        return value
+
+    def vault_constructor(loader, node):
+        if vault_hvac_client is None:
+            raise VaultClientNotInitializedError(
+                f"Vault client not available for !VAULT tag. Ensure {VAULT_ADDR_ENV_VAR} and auth variables are correctly set and client initialized."
+            )
+        # No need to check is_authenticated here if _get_vault_client guarantees it or raises an error.
+
+        value_str = loader.construct_scalar(node)
+        parts = value_str.split(':', 1)
+        if len(parts) != 2:
+            raise VaultInvalidFormatError(f"Invalid !VAULT format '{value_str}'. Expected 'path/to/secret:key_in_secret'.")
+
+        secret_path, secret_key = parts[0], parts[1]
+        response_data = None # Инициализируем
+
+        # Блок try-except только для взаимодействия с клиентом hvac
+        try:
+            # print(f"INFO: Reading secret from Vault. Path: '{secret_path}', Key: '{secret_key}'") # Меньше INFO
+            response_data = vault_hvac_client.secrets.kv.v2.read_secret_version(path=secret_path, raise_on_deleted_version=True)
+        except hvac.exceptions.InvalidPath as e:
+            raise VaultInvalidPathError(f"Invalid path for secret in Vault: '{secret_path}'. Details: {e}") from e
+        except hvac.exceptions.Forbidden as e:
+            raise VaultPermissionError(f"Permission denied for secret in Vault: '{secret_path}'. Check Vault ACL policies. Details: {e}") from e
+        except hvac.exceptions.VaultError as e: # Другие ошибки клиента Vault (например, 500, недоступность)
+            raise VaultGenericClientError(f"Vault API error when reading secret '{secret_path}': {e}") from e
+        except Exception as e: # Действительно неожиданные ошибки во время вызова hvac, не являющиеся hvac.exceptions.VaultError
+            raise KeylockerVaultError(f"An unexpected low-level error occurred during Vault communication for path '{secret_path}': {type(e).__name__} - {e}") from e
+
+        # Если вызов к Vault прошел без исключений hvac, обрабатываем ответ
+        # Ошибки, возбуждаемые здесь, являются ошибками нашей логики парсинга ответа
+        if response_data and 'data' in response_data and 'data' in response_data['data']:
+            secret_data_map = response_data['data']['data']
+            if secret_key in secret_data_map:
+                return secret_data_map[secret_key]
+            else:
+                # Ключ не найден в полученных данных
+                raise VaultKeyNotFoundError(f"Key '{secret_key}' not found in secret data at Vault path '{secret_path}'.")
+        else:
+            # Ответ от Vault получен, но его структура некорректна или данные отсутствуют
+            raise VaultSecretNotFoundError(f"Secret data malformed or not found at Vault path '{secret_path}'. Response structure: {response_data}")
+
 
     KeylockerLoader.add_constructor('!SEC', sec_constructor)
     KeylockerLoader.add_constructor('!ENV', env_constructor)
+    KeylockerLoader.add_constructor('!VAULT', vault_constructor)
     return KeylockerLoader
 
-# Dumper: Encrypt SecureString, Format EnvVariable
-def keylocker_dumper(key_file=DEFAULT_KEY_FILE):
-    """Creates a YAML Dumper that handles SecureString and EnvVariable."""
-    key_bytes = _load_fernet_key(key_file)
-    if not key_bytes:
-        print("WARNING: No encryption key loaded. Cannot encrypt values for !SEC tags.")
-        fernet = None
-    else:
-        try:
-            fernet = Fernet(key_bytes)
-        except Exception as e:
-            print(f"ERROR: Failed to initialize Fernet with the loaded key: {e}")
-            fernet = None
+# Dumper
+def keylocker_dumper(key_file_path=DEFAULT_KEY_FILE): # Renamed arg
+    fernet_cipher = None
+    try:
+        loaded_fernet_key_bytes = _load_fernet_key(key_file_path)
+        fernet_cipher = Fernet(loaded_fernet_key_bytes)
+    except (KeylockerFileError, KeylockerEncryptionError) as e:
+        # If key is not available/usable, dumper cannot encrypt.
+        # This will be raised by sec_representer if called.
+        # We can print a warning here, but sec_representer will be the one to raise if needed.
+        print(f"WARNING: Fernet key not loaded for dumper (path: '{key_file_path}'): {e}. !SEC tags cannot be encrypted.", file=sys.stderr)
+        fernet_cipher = None # Ensure it's None
 
-    class KeylockerDumper(yaml.SafeDumper):
-        pass
+    class KeylockerDumper(yaml.SafeDumper): pass
 
-    def sec_representer(dumper, data):
-         if fernet is None:
-             print("ERROR: Cannot represent SecureString as !SEC: No valid key loaded.")
-             # Represent as plain string with a warning prefix maybe?
-             return dumper.represent_scalar('tag:yaml.org,2002:str', f"ENCRYPTION_ERROR[NoKey]: {data}")
+    def sec_representer(dumper, data: SecureString):
+         if fernet_cipher is None:
+             raise KeylockerEncryptionError(
+                 f"Cannot represent SecureString as !SEC: Fernet encryption cipher not available. "
+                 f"Ensure key file '{key_file_path}' exists or {ENV_VAR_NAME} is set correctly for dumping."
+             )
          try:
-            encrypted_value = fernet.encrypt(str(data).encode()).decode()
-            # Use style='|' for literal block scalar automatically if multiline,
-            # otherwise default (usually plain scalar)
+            encrypted_value = fernet_cipher.encrypt(str(data).encode()).decode()
             style = '|' if '\n' in encrypted_value else None
             return dumper.represent_scalar('!SEC', encrypted_value, style=style)
-         except Exception as e:
-            print(f"ERROR: Failed to encrypt SecureString: {e}")
-            return dumper.represent_scalar('tag:yaml.org,2002:str', f"ENCRYPTION_ERROR[{type(e).__name__}]: {data}")
+         except Exception as e: # Should be rare if Fernet object is valid
+            raise KeylockerEncryptionError(f"Failed to encrypt SecureString value: {e}") from e
 
-
-    def env_representer(dumper, data):
-         return dumper.represent_scalar('!ENV', str(data))
+    def env_representer(dumper, data: EnvVariable):
+         return dumper.represent_scalar('!ENV', str(data)) # No encryption involved
 
     KeylockerDumper.add_representer(SecureString, sec_representer)
     KeylockerDumper.add_representer(EnvVariable, env_representer)
     return KeylockerDumper
 
+
 # --- Core Functions ---
-
-def load_yaml_secrets(file_path, key_file=DEFAULT_KEY_FILE):
-    """Loads YAML, decrypting !SEC and resolving !ENV."""
+def load_yaml_secrets(file_path, key_file_path=DEFAULT_KEY_FILE): # Renamed arg
+    """
+    Loads YAML, decrypting !SEC, resolving !ENV and !VAULT.
+    Raises relevant KeylockerError subclasses or yaml.YAMLError.
+    """
     try:
-        with open(file_path, 'r') as f:
-            # Pass the custom loader initialized with the key file path (for fallback)
-            data = yaml.load(f, Loader=keylocker_loader(key_file))
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = yaml.load(f, Loader=keylocker_loader(key_file_path))
         return data
-    except FileNotFoundError:
-        print(f"ERROR: Input YAML file '{file_path}' not found.")
-        return None
-    except yaml.YAMLError as e:
-        print(f"ERROR: Failed to parse YAML file '{file_path}': {e}")
-        return None
-    except Exception as e:
-        print(f"ERROR: An unexpected error occurred during YAML load: {e}")
-        return None
+    except FileNotFoundError as e:
+        raise KeylockerFileError(f"Input YAML file not found: '{file_path}'") from e
+    except (yaml.YAMLError, KeylockerError): # Includes all our custom errors
+        raise # Propagate as is
+    except Exception as e: # Catch any other unexpected low-level exceptions
+        raise KeylockerError(f"An unexpected error occurred while loading YAML file '{file_path}': {type(e).__name__} - {e}") from e
 
-def encrypt_string_value(value_to_encrypt, key_file=DEFAULT_KEY_FILE):
-    """Encrypts a string and returns the !SEC tagged value."""
-    key_bytes = _load_fernet_key(key_file)
-    if not key_bytes:
-        print("ERROR: Failed to load a valid encryption key for encryption.")
-        return None # Indicate failure
+def encrypt_string_value(value_to_encrypt, key_file_path=DEFAULT_KEY_FILE): # Renamed arg
+    """
+    Encrypts a string using the Fernet key.
+    Returns the !SEC tagged string.
+    Raises KeylockerEncryptionError or KeylockerFileError.
+    """
+    # _load_fernet_key will raise if key is not found/invalid
+    key_bytes = _load_fernet_key(key_file_path)
     try:
         fernet = Fernet(key_bytes)
         encrypted = fernet.encrypt(str(value_to_encrypt).encode()).decode()
-        # Return the full tag representation ready for YAML
         return f"!SEC {encrypted}"
-    except Exception as e:
-         print(f"ERROR: An unexpected error occurred during encryption: {e}")
-         return None
+    except Exception as e: # Any error during Fernet ops
+         raise KeylockerEncryptionError(f"Failed to encrypt string value: {e}") from e
 
 # --- CLI Manager ---
-
 class Manager(object):
-    def __init__(self, key_file=DEFAULT_KEY_FILE):
-        # Store the key file path mainly for the 'init' command
-        self.key_file = key_file
+    def __init__(self, key_file=DEFAULT_KEY_FILE): # 'key_file' is the name used by python-fire
+        self.key_file_path = key_file # Use a more descriptive internal name
 
-    def _check_key_available(self):
-         """Checks if an encryption key is available via env var or file."""
-         key_bytes = _load_fernet_key(self.key_file)
-         if not key_bytes:
-              print(f"ERROR: No valid encryption key found.")
-              print(f"Ensure {ENV_VAR_NAME} environment variable is set,")
-              print(f"or run 'keylocker init' to create '{self.key_file}'.")
-              return False
-         return True # Key is available
+    def _ensure_key_available_for_encryption(self):
+        """Ensures Fernet key is loaded, raises KeylockerError if not. For commands needing encryption."""
+        try:
+            _load_fernet_key(self.key_file_path) # Just to check availability and validity
+        except (KeylockerFileError, KeylockerEncryptionError) as e:
+            # Re-wrap for a more CLI-friendly top-level error for this specific check
+            raise KeylockerConfigError(
+                f"Fernet encryption key is not available or invalid. Cannot proceed. Details: {e}\n"
+                f"Ensure {ENV_VAR_NAME} is set or run 'keylocker init' (for key file '{self.key_file_path}')."
+            ) from e
+
 
     def init(self, force=False):
-        """
-        Initializes storage by generating the master key file.
-        This command ALWAYS interacts with the key FILE, not the env var.
-        """
-        key_path = self.key_file
+        """Initializes Fernet key file storage."""
+        key_path = self.key_file_path
         env_key_set = os.environ.get(ENV_VAR_NAME)
 
         if os.path.exists(key_path) and not force:
-            print(f"Key file '{key_path}' already exists.")
+            print(f"Fernet key file '{key_path}' already exists.")
             if env_key_set:
-                print(f"Note: Environment variable {ENV_VAR_NAME} is set and will take precedence over this file for operations.")
-            print("Use --force to overwrite the file.")
-            return f"Key file '{key_path}' already exists."
-
-        print(f"Generating new key file: '{key_path}'...")
-        # Using Fernet's key generation directly is simpler and sufficient
-        key = Fernet.generate_key() # This key is already base64 encoded bytes
+                print(f"Note: Environment variable {ENV_VAR_NAME} is set and will take precedence for !SEC operations.")
+            print("Use --force to overwrite the Fernet key file.")
+            return # Successful no-op
 
         try:
+            print(f"Generating new Fernet key file: '{key_path}'...")
+            key = Fernet.generate_key()
             with open(key_path, 'wb') as f:
                 f.write(key)
-            print(f"Successfully created key file: '{key_path}'")
+            print(f"Successfully created Fernet key file: '{key_path}'")
             if env_key_set:
-                print(f"Note: Environment variable {ENV_VAR_NAME} is set and will take precedence over this file for operations.")
-            return f"Key file '{key_path}' created."
+                print(f"Note: Environment variable {ENV_VAR_NAME} is set and will take precedence for !SEC operations.")
         except IOError as e:
-            print(f"ERROR: Could not write key file '{key_path}': {e}")
-            sys.exit(996)
+            print(f"ERROR: Could not write Fernet key file '{key_path}': {e}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as e:
+            print(f"ERROR: Unexpected error during Fernet key generation for '{key_path}': {e}", file=sys.stderr)
+            sys.exit(1)
 
-    def encrypt(self, value):
-        """Encrypts a string value using the key and prints the !SEC tag."""
-        if not self._check_key_available():
-            sys.exit(1) # Exit if no key
-        encrypted_tag = encrypt_string_value(value, self.key_file)
-        if encrypted_tag:
-             print("Add the following line to your YAML file:")
-             print(encrypted_tag)
-        else:
-             # Error message already printed by encrypt_string_value or _load_fernet_key
-             sys.exit(1) # Exit with error code
 
-    def view(self, yaml_file):
-        """Loads, decrypts (!SEC), resolves (!ENV) a YAML file and prints it."""
-        # _check_key_available is implicitly called by load_yaml_secrets -> keylocker_loader -> _load_fernet_key
-        # No need to call it explicitly here unless we want the error message earlier.
-        data = load_yaml_secrets(yaml_file, self.key_file)
-        if data is not None:
-             # Dump back to YAML string for viewing (without custom tags, values resolved)
-             # Use standard SafeDumper for output
-             print(yaml.dump(data, Dumper=yaml.SafeDumper, default_flow_style=False, sort_keys=False, allow_unicode=True))
-        else:
-            # Error messages were likely printed during loading
-            sys.exit(1) # Exit with error code if loading failed
+    def encrypt(self, value: str):
+        """Encrypts a string value using the Fernet key and prints the !SEC tag."""
+        try:
+            self._ensure_key_available_for_encryption() # Will raise if key is bad
+            encrypted_tag = encrypt_string_value(value, self.key_file_path)
+            print("Add the following line to your YAML file for the encrypted value:")
+            print(encrypted_tag)
+        except (KeylockerConfigError, KeylockerEncryptionError) as e: # Catch errors from check or encryption
+            print(f"ERROR: Encryption failed. {e}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as e: # Catch-all for other unexpected errors
+            print(f"ERROR: An unexpected error occurred during encryption: {type(e).__name__} - {e}", file=sys.stderr)
+            sys.exit(1)
 
-# --- Main execution ---
+
+    def view(self, yaml_file: str):
+        """Loads, decrypts (!SEC), and resolves (!ENV, !VAULT) a YAML file, then prints it."""
+        print(f"Attempting to load and process YAML file: '{yaml_file}'...")
+        try:
+            data = load_yaml_secrets(yaml_file, self.key_file_path)
+            print("\nProcessed YAML content:")
+            print(yaml.dump(data, Dumper=yaml.SafeDumper, default_flow_style=False, sort_keys=False, allow_unicode=True))
+        except KeylockerFileError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+        except yaml.YAMLError as e:
+            print(f"ERROR: Invalid YAML syntax in '{yaml_file}'.", file=sys.stderr)
+            print(f"Details: {e}", file=sys.stderr)
+            sys.exit(1)
+        except KeylockerVaultError as e:
+            print(f"ERROR: Vault secret processing failed in '{yaml_file}': {e}", file=sys.stderr)
+            sys.exit(1)
+        except KeylockerEncryptionError as e:
+            print(f"ERROR: Encryption/decryption process failed in '{yaml_file}': {e}", file=sys.stderr)
+            sys.exit(1)
+        except KeylockerConfigError as e: # For errors like Fernet key setup during loader init
+             print(f"ERROR: Configuration problem for '{yaml_file}': {e}", file=sys.stderr)
+             sys.exit(1)
+        except KeylockerError as e: # Other keylocker errors
+            print(f"ERROR: Failed to process secrets in '{yaml_file}': {e}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as e:
+            print(f"ERROR: An unexpected critical error occurred while viewing '{yaml_file}': {type(e).__name__} - {e}", file=sys.stderr)
+            sys.exit(1)
 
 def main():
-    # Pass Manager class directly to Fire
     fire.Fire(Manager, name='keylocker')
 
 if __name__ == "__main__":

--- a/tests/test_keylocker_vault.py
+++ b/tests/test_keylocker_vault.py
@@ -1,0 +1,341 @@
+import os
+import pytest
+import yaml
+from unittest.mock import patch, MagicMock
+
+# Импортируем тестируемые функции и классы исключений из вашего модуля
+# Предполагается, что keylocker находится в PYTHONPATH или установлен
+from keylocker import (
+    load_yaml_secrets,
+    VaultClientNotInitializedError,
+    VaultInvalidFormatError,
+    VaultSecretNotFoundError,
+    VaultKeyNotFoundError,
+    VaultInvalidPathError,
+    VaultPermissionError,
+    VaultGenericClientError,
+    ENV_VAR_NAME,  # KEYLOCKER_SECRET_KEY
+    VAULT_ADDR_ENV_VAR,
+    VAULT_TOKEN_ENV_VAR
+)
+# Импортируем hvac.exceptions для мокирования специфичных ошибок hvac
+import hvac.exceptions
+
+# tests/test_keylocker_vault.py
+
+import os
+import pytest
+import yaml # Убедитесь, что yaml импортирован
+from unittest.mock import patch, MagicMock
+from cryptography.fernet import Fernet
+
+# Импортируем тестируемые функции и классы исключений из вашего модуля
+from keylocker import (
+    load_yaml_secrets,
+    KeylockerFileError, # Для теста отсутствующего YAML файла
+    KeylockerConfigError,
+    VaultClientNotInitializedError,
+    VaultInvalidFormatError,
+    VaultSecretNotFoundError,
+    VaultKeyNotFoundError,
+    VaultInvalidPathError,
+    VaultPermissionError,
+    VaultGenericClientError,
+    # ENV_VAR_NAME, # Не используется напрямую в этих тестах Vault
+    VAULT_ADDR_ENV_VAR,
+    VAULT_TOKEN_ENV_VAR
+)
+# Импортируем hvac.exceptions для мокирования специфичных ошибок hvac
+import hvac.exceptions
+
+# Фикстура для временных YAML файлов (без изменений)
+@pytest.fixture
+def create_yaml_file(tmp_path):
+    def _create_yaml_file(content):
+        file_path = tmp_path / "test.yaml"
+        with open(file_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return file_path
+    return _create_yaml_file
+
+# Фикстура для управления переменными окружения (без изменений)
+@pytest.fixture
+def mock_env_vars(mocker):
+    def _mock_env_vars(env_vars_dict, clear_others=True): # clear=True по умолчанию
+        return mocker.patch.dict(os.environ, env_vars_dict, clear=clear_others)
+    return _mock_env_vars
+
+# Фикстура для мокирования клиента HVAC (без изменений)
+@pytest.fixture
+def mock_hvac_client(mocker):
+    mock_client_instance = MagicMock(spec=hvac.Client)
+    mock_client_constructor = mocker.patch('hvac.Client', return_value=mock_client_instance)
+    return mock_client_constructor, mock_client_instance
+
+# --- Тесты ---
+
+def test_load_yaml_file_not_found():
+    """Тест: YAML файл не найден, ожидаем KeylockerFileError."""
+    with pytest.raises(KeylockerFileError) as excinfo:
+        load_yaml_secrets("non_existent_file.yaml")
+    assert "Input YAML file not found: 'non_existent_file.yaml'" in str(excinfo.value)
+
+
+def test_load_yaml_with_vault_success(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест успешной загрузки секрета из Vault."""
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "fake_token"})
+    _, mock_client = mock_hvac_client # mock_client_constructor не используется здесь напрямую
+    mock_client.is_authenticated.return_value = True
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {
+        'data': {
+            'data': {'db_password': 'supersecretpassword'}
+        }
+    }
+
+    yaml_content = "config:\n  password: !VAULT kv/data/myapp/db:db_password"
+    yaml_file = create_yaml_file(yaml_content)
+
+    result = load_yaml_secrets(str(yaml_file))
+
+    assert result['config']['password'] == 'supersecretpassword'
+    mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+        path='kv/data/myapp/db', raise_on_deleted_version=True
+    )
+
+def test_load_yaml_vault_addr_not_set_but_vault_tag_used(create_yaml_file, mock_env_vars, capsys):
+    """
+    Тест: VAULT_ADDR не установлен, но используется !VAULT.
+    Ожидаем VaultClientNotInitializedError от vault_constructor.
+    """
+    mock_env_vars({}) # VAULT_ADDR и VAULT_TOKEN не установлены
+    yaml_content = "config:\n  password: !VAULT kv/data/myapp/db:db_password"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultClientNotInitializedError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+
+    # Это исключение возбуждается из vault_constructor
+    assert "Vault client not available for !VAULT tag." in str(excinfo.value)
+
+    captured = capsys.readouterr()
+    # keylocker_loader напечатает INFO, т.к. _get_vault_client не будет вызван
+    assert f"INFO: Environment variable '{VAULT_ADDR_ENV_VAR}' is not set." in captured.out
+    assert "Vault client will not be initialized. !VAULT tags will fail if used." in captured.out
+
+
+def test_load_yaml_vault_token_not_set(create_yaml_file, mock_env_vars, mock_hvac_client, capsys):
+    """
+    Тест: VAULT_ADDR установлен, но VAULT_TOKEN не установлен.
+    _get_vault_client должен возбудить VaultClientNotInitializedError.
+    (При условии, что _get_vault_client теперь требует токен, если VAULT_ADDR установлен).
+    """
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200"}) # VAULT_TOKEN не установлен
+    # Мокируем hvac.Client, т.к. _get_vault_client попытается его создать
+    mock_constructor, _ = mock_hvac_client
+
+    yaml_content = "config:\n  password: !VAULT kv/data/myapp/db:db_password"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultClientNotInitializedError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+
+    assert f"Vault token environment variable '{VAULT_TOKEN_ENV_VAR}' not set" in str(excinfo.value)
+
+
+def test_load_yaml_vault_auth_fails_in_get_client(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """
+    Тест: Аутентификация Vault не удалась в _get_vault_client (is_authenticated => False).
+    Ожидаем VaultClientNotInitializedError от _get_vault_client.
+    """
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "bad_token"})
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = False # Аутентификация не удалась
+
+    yaml_content = "config:\n  password: !VAULT kv/data/myapp/db:db_password"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultClientNotInitializedError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+
+    assert "Failed to authenticate to Vault at http://fake-vault:8200" in str(excinfo.value)
+
+
+def test_load_yaml_vault_client_init_raises_hvac_vault_error(create_yaml_file, mock_env_vars, mocker):
+    """
+    Тест: hvac.Client() возбуждает hvac.exceptions.VaultError при инициализации.
+    _get_vault_client должен поймать и возбудить VaultClientNotInitializedError.
+    """
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://unreachable-vault:8200", VAULT_TOKEN_ENV_VAR: "any-token"})
+    mocker.patch('hvac.Client', side_effect=hvac.exceptions.VaultError("Connection refused by mock"))
+
+    yaml_content = "config:\n  password: !VAULT kv/data/myapp/db:db_password"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultClientNotInitializedError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+
+    assert "Vault client setup/connection error for http://unreachable-vault:8200" in str(excinfo.value)
+    assert "Connection refused by mock" in str(excinfo.value)
+
+
+def test_load_yaml_vault_invalid_tag_format(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест: неверный формат тега !VAULT."""
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "fake_token"})
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = True
+
+    yaml_content = "config:\n  password: !VAULT kv/data/myapp/db_NO_KEY_SEPARATOR"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultInvalidFormatError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+    assert "Invalid !VAULT format 'kv/data/myapp/db_NO_KEY_SEPARATOR'" in str(excinfo.value)
+
+def test_load_yaml_vault_key_not_found(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест: ключ не найден в секрете Vault."""
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "fake_token"})
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = True
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {
+        'data': {
+            'data': {'another_key': 'some_value'}
+        }
+    }
+    yaml_content = "config:\n  password: !VAULT kv/data/myapp/db:missing_key"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultKeyNotFoundError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+    assert "Key 'missing_key' not found" in str(excinfo.value)
+    assert "Vault path 'kv/data/myapp/db'" in str(excinfo.value)
+
+
+def test_load_yaml_vault_secret_not_found_empty_data(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест: секрет не найден (ответ Vault пустой или без data.data)."""
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "fake_token"})
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = True
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {'data': {}} # Не 'data' внутри 'data'
+
+    yaml_content = "config:\n  password: !VAULT non/existent/path:some_key"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultSecretNotFoundError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+    assert "Secret data malformed or not found at Vault path 'non/existent/path'" in str(excinfo.value)
+
+
+def test_load_yaml_vault_api_raises_invalid_path(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест: API Vault возвращает ошибку InvalidPath."""
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "fake_token"})
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = True
+    mock_client.secrets.kv.v2.read_secret_version.side_effect = hvac.exceptions.InvalidPath("Mocked InvalidPath from HVAC")
+
+    yaml_content = "config:\n  password: !VAULT bad/path:some_key"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultInvalidPathError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+    assert "Invalid path for secret in Vault: 'bad/path'" in str(excinfo.value)
+    assert "Mocked InvalidPath from HVAC" in str(excinfo.value) # Проверяем, что оригинальное сообщение hvac включено
+
+
+def test_load_yaml_vault_api_raises_forbidden(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест: API Vault возвращает ошибку Forbidden."""
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "fake_token"})
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = True
+    mock_client.secrets.kv.v2.read_secret_version.side_effect = hvac.exceptions.Forbidden("Mocked Forbidden from HVAC")
+
+    yaml_content = "config:\n  password: !VAULT forbidden/path:some_key"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultPermissionError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+    assert "Permission denied for secret in Vault: 'forbidden/path'" in str(excinfo.value)
+    assert "Mocked Forbidden from HVAC" in str(excinfo.value)
+
+
+def test_load_yaml_vault_api_raises_generic_vault_error(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест: API Vault возвращает общую ошибку VaultError."""
+    mock_env_vars({VAULT_ADDR_ENV_VAR: "http://fake-vault:8200", VAULT_TOKEN_ENV_VAR: "fake_token"})
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = True
+    mock_client.secrets.kv.v2.read_secret_version.side_effect = hvac.exceptions.VaultError("Mocked Generic VaultError from HVAC")
+
+    yaml_content = "config:\n  password: !VAULT some/path:some_key"
+    yaml_file = create_yaml_file(yaml_content)
+
+    with pytest.raises(VaultGenericClientError) as excinfo:
+        load_yaml_secrets(str(yaml_file))
+    assert "Vault API error when reading secret 'some/path'" in str(excinfo.value)
+    assert "Mocked Generic VaultError from HVAC" in str(excinfo.value)
+
+
+def test_load_yaml_with_env_and_vault_success(create_yaml_file, mock_env_vars, mock_hvac_client):
+    """Тест совместной работы !ENV и !VAULT при успешном выполнении."""
+    mock_env_vars({
+        VAULT_ADDR_ENV_VAR: "http://fake-vault:8200",
+        VAULT_TOKEN_ENV_VAR: "fake_token",
+        "MY_ENV_VAR_FOR_TEST": "env_value_123"  # Уникальное имя для переменной окружения
+    })
+    _, mock_client = mock_hvac_client
+    mock_client.is_authenticated.return_value = True
+    mock_client.secrets.kv.v2.read_secret_version.return_value = {
+        'data': {'data': {'secret_key': 'vault_value_456'}}
+    }
+
+    yaml_content = (
+        "app:\n"
+        "  setting1: !ENV MY_ENV_VAR_FOR_TEST\n"
+        "  setting2: !VAULT my/vault/path:secret_key"
+    )
+    yaml_file = create_yaml_file(yaml_content)
+    result = load_yaml_secrets(str(yaml_file))
+
+    assert result['app']['setting1'] == 'env_value_123'
+    assert result['app']['setting2'] == 'vault_value_456'
+
+# --- Тесты для Fernet ключей и !SEC (примеры, можно вынести в отдельный файл) ---
+
+@pytest.fixture
+def mock_fernet_key_env(mock_env_vars):
+    """Мокирует валидный Fernet ключ в переменной окружения."""
+    # Этот ключ сгенерирован Fernet.generate_key().decode()
+    valid_key_str = Fernet.generate_key().decode()
+    mock_env_vars({ENV_VAR_NAME: valid_key_str}, clear_others=False) # Добавляем, не очищая другие
+    return valid_key_str
+
+@pytest.fixture
+def create_fernet_key_file(tmp_path):
+    """Создает валидный файл Fernet ключа."""
+    key_file = tmp_path / "test_storage.key"
+    key = Fernet.generate_key()
+    with open(key_file, "wb") as f:
+        f.write(key)
+    return str(key_file), key.decode()
+
+
+def test_load_yaml_sec_tag_success_with_env_key(create_yaml_file, mock_fernet_key_env, capsys):
+    """Тест успешной расшифровки !SEC тега с ключом из переменной окружения."""
+    key_str = mock_fernet_key_env
+    fernet = Fernet(key_str.encode())
+    original_value = "my_secret_data"
+    encrypted_value = fernet.encrypt(original_value.encode()).decode()
+
+    yaml_content = f"secret_data: !SEC {encrypted_value}"
+    yaml_file = create_yaml_file(yaml_content)
+
+    # Убедимся, что VAULT_ADDR не установлен, чтобы не мешать тесту !SEC
+    with patch.dict(os.environ, {VAULT_ADDR_ENV_VAR: ""}, clear=False):
+        if VAULT_ADDR_ENV_VAR in os.environ: # Доп. проверка для очистки если он был установлен ранее в сессии
+            del os.environ[VAULT_ADDR_ENV_VAR]
+
+        result = load_yaml_secrets(str(yaml_file)) # Используем ключ по умолчанию, т.к. _load_fernet_key проверит env
+
+    assert result['secret_data'] == original_value
+    captured = capsys.readouterr()
+    assert f"INFO: Using encryption key from environment variable {ENV_VAR_NAME}" in captured.out
+
+# Добавьте больше тестов для !SEC, !ENV, ошибок Fernet ключей, и т.д.

--- a/tests/test_keylocker_yaml.py
+++ b/tests/test_keylocker_yaml.py
@@ -11,17 +11,20 @@ from keylocker import (
     Manager,
     load_yaml_secrets,
     encrypt_string_value,
-    # Вспомогательные переменные или функции, если они доступны и нужны
     DEFAULT_KEY_FILE,
-    ENV_VAR_NAME # Имя переменной окружения с ключом
+    ENV_VAR_NAME, # Имя переменной окружения с ключом
+    # Кастомные исключения
+    KeylockerFileError,
+    KeylockerEncryptionError,
+    KeylockerConfigError # Может понадобиться для ошибок конфигурации ключа
 )
 
-# --- Fixtures ---
+# --- Fixtures (остаются как есть, они хорошо написаны) ---
 
 @pytest.fixture(scope="function")
 def temp_dir(tmp_path_factory):
     """Создает временную директорию для каждого теста."""
-    return tmp_path_factory.mktemp("keylocker_test")
+    return tmp_path_factory.mktemp("keylocker_test_yaml") # Изменено имя для ясности
 
 @pytest.fixture(scope="function")
 def key_file_in_temp_dir(temp_dir):
@@ -31,68 +34,69 @@ def key_file_in_temp_dir(temp_dir):
 @pytest.fixture(scope="function")
 def generated_key_file(key_file_in_temp_dir):
     """Фикстура для создания валидного файла ключа во временной директории."""
+    # Убедимся, что переменная окружения не мешает генерации файла
+    if ENV_VAR_NAME in os.environ:
+        del os.environ[ENV_VAR_NAME]
     manager = Manager(key_file=str(key_file_in_temp_dir))
-    manager.init(force=True)
+    manager.init(force=True) # force=True на случай, если файл остался от предыдущего запуска
     assert key_file_in_temp_dir.exists()
     return str(key_file_in_temp_dir)
 
 @pytest.fixture(scope="function")
-def valid_fernet_key():
+def valid_fernet_key_bytes(): # Переименовано для ясности, что это байты
     """Генерирует и возвращает валидный ключ Fernet в виде байтов."""
     return Fernet.generate_key()
 
 @pytest.fixture(scope="function")
-def set_env_key(monkeypatch, valid_fernet_key):
+def set_env_key(monkeypatch, valid_fernet_key_bytes):
     """Фикстура для установки переменной окружения с ключом."""
-    key_str = valid_fernet_key.decode('utf-8')
+    key_str = valid_fernet_key_bytes.decode('utf-8')
     monkeypatch.setenv(ENV_VAR_NAME, key_str)
-    # Возвращаем сам ключ для возможного использования в тесте
-    yield valid_fernet_key
-    # Очистка происходит автоматически благодаря monkeypatch
+    yield valid_fernet_key_bytes # Возвращаем байты ключа для использования в тесте
+    monkeypatch.delenv(ENV_VAR_NAME, raising=False) # Явная очистка, хотя monkeypatch делает это
 
 @pytest.fixture(scope="function")
 def unset_env_key(monkeypatch):
     """Фикстура для гарантии, что переменная окружения НЕ установлена."""
-    monkeypatch.delenv(ENV_VAR_NAME, raising=False) # Не вызывать ошибку, если ее и так нет
+    monkeypatch.delenv(ENV_VAR_NAME, raising=False)
 
 @pytest.fixture
 def yaml_file_factory(temp_dir):
     """Фабрика для создания временных YAML файлов с заданным содержимым."""
     def _create_yaml(filename="test_config.yaml", content=""):
         yaml_path = temp_dir / filename
-        yaml_path.write_text(content)
+        yaml_path.write_text(content, encoding='utf-8')
         return str(yaml_path)
     return _create_yaml
 
 # --- Test Functions ---
 
-# === Тесты команды init ===
+# === Тесты команды init (остаются без изменений, т.к. тестируют CLI поведение) ===
 def test_init_creates_key_file(key_file_in_temp_dir, unset_env_key):
     """Тест: keylocker init создает файл ключа."""
     assert not key_file_in_temp_dir.exists()
     manager = Manager(key_file=str(key_file_in_temp_dir))
     manager.init()
     assert key_file_in_temp_dir.exists()
-    # Проверим, что ключ валиден
     key_bytes = key_file_in_temp_dir.read_bytes()
-    assert len(key_bytes) > 30
+    assert len(key_bytes) > 30 # Проверка на разумную длину ключа
     Fernet(key_bytes) # Должно работать без исключений
 
 def test_init_does_not_overwrite_by_default(generated_key_file, unset_env_key):
     """Тест: keylocker init не перезаписывает существующий ключ без --force."""
     manager = Manager(key_file=generated_key_file)
     initial_content = open(generated_key_file, 'rb').read()
-    result = manager.init() # Без force
-    assert "already exists" in result
+    # Захватываем stdout, чтобы проверить сообщение
+    # Manager.init печатает сообщения, но не возвращает их напрямую для этого случая
+    # Вместо этого можно проверить, что файл не изменился
+    manager.init() # Без force
     assert open(generated_key_file, 'rb').read() == initial_content
 
 def test_init_force_overwrites(generated_key_file, unset_env_key):
     """Тест: keylocker init --force перезаписывает существующий ключ."""
     manager = Manager(key_file=generated_key_file)
     initial_content = open(generated_key_file, 'rb').read()
-    result = manager.init(force=True)
-    assert "created." in result
-    # Убедимся, что файл действительно перезаписан
+    manager.init(force=True)
     assert open(generated_key_file, 'rb').read() != initial_content
 
 # === Тесты шифрования (encrypt_string_value) ===
@@ -102,7 +106,6 @@ def test_encrypt_string_with_file_key(generated_key_file, unset_env_key):
     encrypted_tag = encrypt_string_value(plain_text, generated_key_file)
     assert encrypted_tag is not None
     assert encrypted_tag.startswith("!SEC ")
-    # Расшифруем для проверки
     key_bytes = open(generated_key_file, 'rb').read()
     fernet = Fernet(key_bytes)
     decrypted = fernet.decrypt(encrypted_tag.split(" ", 1)[1].encode()).decode()
@@ -110,29 +113,47 @@ def test_encrypt_string_with_file_key(generated_key_file, unset_env_key):
 
 def test_encrypt_string_with_env_key(set_env_key):
     """Тест шифрования строки с использованием ключа из переменной окружения."""
-    env_key_bytes = set_env_key # Получаем ключ из фикстуры
+    env_key_bytes = set_env_key
     plain_text = "secret env data"
-    # Передаем любой путь к файлу, он не должен использоваться
-    encrypted_tag = encrypt_string_value(plain_text, "non_existent_file.key")
+    # key_file_path не должен использоваться, если ключ есть в env
+    encrypted_tag = encrypt_string_value(plain_text, "dummy_path.key")
     assert encrypted_tag is not None
     assert encrypted_tag.startswith("!SEC ")
-    # Расшифруем для проверки
     fernet = Fernet(env_key_bytes)
     decrypted = fernet.decrypt(encrypted_tag.split(" ", 1)[1].encode()).decode()
     assert decrypted == plain_text
 
-def test_encrypt_string_no_key(key_file_in_temp_dir, unset_env_key):
-    """Тест: Шифрование не работает без ключа (ни файла, ни env var)."""
-    assert not key_file_in_temp_dir.exists() # Убедимся, что файла нет
-    encrypted_tag = encrypt_string_value("data", str(key_file_in_temp_dir))
-    assert encrypted_tag is None # Ожидаем ошибку (None)
+def test_encrypt_string_no_key_raises_error(key_file_in_temp_dir, unset_env_key): # <--- ОБНОВЛЕНО
+    """Тест: Шифрование возбуждает KeylockerFileError, если нет ключа."""
+    assert not key_file_in_temp_dir.exists()
+    with pytest.raises(KeylockerFileError) as excinfo:
+        encrypt_string_value("data", str(key_file_in_temp_dir))
+    assert f"Fernet key file '{str(key_file_in_temp_dir)}' not found" in str(excinfo.value)
+    assert ENV_VAR_NAME in str(excinfo.value) # Проверка, что сообщение упоминает ENV_VAR_NAME
+
+def test_encrypt_string_invalid_key_file_raises_error(yaml_file_factory, unset_env_key): # <--- НОВЫЙ ТЕСТ
+    """Тест: Шифрование возбуждает KeylockerEncryptionError, если файл ключа поврежден."""
+    invalid_key_file = yaml_file_factory("invalid.key", "this is not a valid key")
+    with pytest.raises(KeylockerEncryptionError) as excinfo:
+        encrypt_string_value("data", invalid_key_file)
+    assert "Invalid key format in Fernet key file" in str(excinfo.value) or \
+           "Failed to encrypt string value" in str(excinfo.value) # Сообщение от encrypt_string_value
+
+def test_encrypt_string_invalid_env_key_raises_error(monkeypatch, unset_env_key): # <--- НОВЫЙ ТЕСТ
+    """Тест: Шифрование возбуждает KeylockerEncryptionError, если ключ в env поврежден."""
+    monkeypatch.setenv(ENV_VAR_NAME, "this-is-not-a-base64-fernet-key")
+    with pytest.raises(KeylockerEncryptionError) as excinfo:
+        encrypt_string_value("data", "dummy_path.key")
+    assert "Invalid key format in environment variable" in str(excinfo.value) or \
+           "Failed to encrypt string value" in str(excinfo.value)
+
 
 # === Тесты загрузки YAML (load_yaml_secrets) ===
-def test_load_yaml_with_file_key(yaml_file_factory, generated_key_file, unset_env_key, monkeypatch):
-    """Тест загрузки YAML с !SEC и !ENV, используя ключ из файла."""
+def test_load_yaml_with_file_key_success(yaml_file_factory, generated_key_file, unset_env_key, monkeypatch):
+    """Тест загрузки YAML с !SEC и !ENV, используя ключ из файла (успех)."""
     secret_value = "file_key_secret"
-    env_var = "TEST_VAR_FILE"
-    env_val = "file_key_env_val"
+    env_var = "TEST_VAR_FILE_YAML"
+    env_val = "file_key_env_val_yaml"
     monkeypatch.setenv(env_var, env_val)
 
     encrypted_tag = encrypt_string_value(secret_value, generated_key_file)
@@ -149,17 +170,16 @@ def test_load_yaml_with_file_key(yaml_file_factory, generated_key_file, unset_en
     assert loaded_data['api_key'] == env_val
     assert loaded_data['plain'] == 'value'
 
-def test_load_yaml_with_env_key(yaml_file_factory, set_env_key, key_file_in_temp_dir, monkeypatch):
-    """Тест загрузки YAML с !SEC и !ENV, используя ключ из переменной окружения."""
+def test_load_yaml_with_env_key_success(yaml_file_factory, set_env_key, key_file_in_temp_dir, monkeypatch):
+    """Тест загрузки YAML с !SEC и !ENV, используя ключ из env (успех)."""
     env_key_bytes = set_env_key
     fernet = Fernet(env_key_bytes)
 
     secret_value = "env_key_secret"
-    env_var = "TEST_VAR_ENV"
-    env_val = "env_key_env_val"
+    env_var = "TEST_VAR_ENV_YAML"
+    env_val = "env_key_env_val_yaml"
     monkeypatch.setenv(env_var, env_val)
 
-    # Шифруем значение ключом из env var для теста
     encrypted_val = fernet.encrypt(secret_value.encode()).decode()
     encrypted_tag = f"!SEC {encrypted_val}"
 
@@ -168,81 +188,93 @@ def test_load_yaml_with_env_key(yaml_file_factory, set_env_key, key_file_in_temp
     api_key: !ENV {env_var}
     plain: value2
     """
-    # Файл ключа не должен существовать или использоваться
-    assert not key_file_in_temp_dir.exists()
+    assert not key_file_in_temp_dir.exists() # Файл ключа не должен использоваться
     yaml_path = yaml_file_factory("config_env.yaml", yaml_content)
 
-    # Передаем путь к несуществующему файлу, т.к. ключ берется из env
-    loaded_data = load_yaml_secrets(yaml_path, str(key_file_in_temp_dir))
+    loaded_data = load_yaml_secrets(yaml_path, str(key_file_in_temp_dir)) # Путь к файлу не важен, если есть env ключ
     assert loaded_data is not None
     assert loaded_data['db_pass'] == secret_value
     assert loaded_data['api_key'] == env_val
     assert loaded_data['plain'] == 'value2'
 
-def test_load_yaml_no_key_fails_sec(yaml_file_factory, key_file_in_temp_dir, unset_env_key, capsys):
-    """Тест: Загрузка YAML с !SEC падает (возвращает ошибку), если нет ключа."""
+def test_load_yaml_no_key_for_sec_tag_raises_error(yaml_file_factory, key_file_in_temp_dir, unset_env_key, capsys): # <--- ОБНОВЛЕНО
+    """Тест: Загрузка YAML с !SEC возбуждает KeylockerEncryptionError, если нет ключа."""
     yaml_content = """
-    secret: !SEC GAAAAAB...invalid...
+    secret: !SEC GAAAAAB...any_encrypted_looking_string...
     plain: value
     """
-    yaml_path = yaml_file_factory("config_no_key.yaml", yaml_content)
-    assert not key_file_in_temp_dir.exists() # Файла нет
+    yaml_path = yaml_file_factory("config_no_key_sec.yaml", yaml_content)
+    assert not key_file_in_temp_dir.exists()
 
-    loaded_data = load_yaml_secrets(yaml_path, str(key_file_in_temp_dir))
-    assert loaded_data is not None # Загрузка YAML не падает полностью
-    assert "DECRYPTION_ERROR[NoKey]" in loaded_data['secret'] # Значение не расшифровано
-    assert loaded_data['plain'] == 'value'
-    # Проверяем сообщения в stderr/stdout
+    with pytest.raises(KeylockerEncryptionError) as excinfo:
+        load_yaml_secrets(yaml_path, str(key_file_in_temp_dir))
+
+    assert "Cannot decrypt !SEC value: Fernet encryption cipher not available" in str(excinfo.value)
+
     captured = capsys.readouterr()
-    assert "No encryption key loaded" in captured.out or "No encryption key loaded" in captured.err # Должно быть предупреждение
-    assert "Cannot decrypt !SEC value" in captured.out or "Cannot decrypt !SEC value" in captured.err # Должна быть ошибка при расшифровке
+    # _load_fernet_key (вызванный из keylocker_loader) напечатает INFO об отсутствии файла ключа
+    assert f"INFO: Fernet key file '{str(key_file_in_temp_dir)}' not found" in captured.out
+    assert ENV_VAR_NAME in captured.out # Сообщение INFO также упоминает ENV_VAR_NAME
 
-def test_load_yaml_env_not_set(yaml_file_factory, generated_key_file, unset_env_key, capsys):
+
+def test_load_yaml_invalid_sec_token_raises_error(yaml_file_factory, generated_key_file, unset_env_key): # <--- НОВЫЙ ТЕСТ
+    """Тест: Загрузка YAML с поврежденным !SEC токеном возбуждает KeylockerEncryptionError."""
+    yaml_content = """
+    secret: !SEC this_is_not_a_valid_fernet_token
+    """
+    yaml_path = yaml_file_factory("config_invalid_token.yaml", yaml_content)
+
+    with pytest.raises(KeylockerEncryptionError) as excinfo:
+        load_yaml_secrets(yaml_path, generated_key_file)
+    assert "Failed to decrypt !SEC value: Invalid token or key mismatch" in str(excinfo.value)
+
+
+def test_load_yaml_env_not_set_returns_none_with_warning(yaml_file_factory, generated_key_file, unset_env_key, capsys): # <--- Название уточнено
     """Тест: !ENV возвращает None и выводит предупреждение, если переменная не установлена."""
-    env_var = "UNSET_TEST_VAR"
+    env_var = "UNSET_TEST_VAR_YAML"
+    # Убедимся, что переменная точно не установлена
+    if env_var in os.environ:
+        del os.environ[env_var]
+
     yaml_content = f"""
     config_val: !ENV {env_var}
     """
     yaml_path = yaml_file_factory("config_unset_env.yaml", yaml_content)
 
     loaded_data = load_yaml_secrets(yaml_path, generated_key_file)
-    assert loaded_data is not None
-    assert loaded_data['config_val'] is None # Ожидаем None
+    assert loaded_data is not None # Сам YAML загружается
+    assert loaded_data['config_val'] is None # Ожидаем None для отсутствующей переменной
+
     captured = capsys.readouterr()
-    assert f"Environment variable '{env_var}' (tagged !ENV) not found" in captured.out or \
-           f"Environment variable '{env_var}' (tagged !ENV) not found" in captured.err
+    # env_constructor печатает в stderr
+    assert f"WARNING: Environment variable '{env_var}' (tagged !ENV) not found. Resolving to None." in captured.err
 
-# === Тесты CLI команд (требуют больше усилий для настройки) ===
 
-# Пример теста команды view через subprocess
-@pytest.mark.skip(reason="CLI tests require careful environment setup")
-def test_cli_view_with_file_key(yaml_file_factory, generated_key_file, unset_env_key, monkeypatch):
-    """(Пример) Тестирование CLI команды 'view' с ключом из файла."""
-    secret_value = "cli_secret"
-    env_var = "CLI_TEST_VAR"
-    env_val = "cli_env_val"
-    monkeypatch.setenv(env_var, env_val)
-    encrypted_tag = encrypt_string_value(secret_value, generated_key_file)
-    yaml_content = f"password: {encrypted_tag}\napi_key: !ENV {env_var}"
-    yaml_path = yaml_file_factory("cli_config.yaml", yaml_content)
+def test_load_yaml_file_itself_not_found_raises_error(unset_env_key): # <--- НОВЫЙ ТЕСТ (аналогичен из vault тестов)
+    """Тест: Загрузка несуществующего YAML файла возбуждает KeylockerFileError."""
+    with pytest.raises(KeylockerFileError) as excinfo:
+        load_yaml_secrets("surely_this_file_does_not_exist.yaml", "dummy.key")
+    assert "Input YAML file not found" in str(excinfo.value)
+    assert "surely_this_file_does_not_exist.yaml" in str(excinfo.value)
 
-    # Запускаем keylocker как подпроцесс
-    # Важно: нужно убедиться, что keylocker установлен в окружении или путь к скрипту правильный
-    result = subprocess.run(
-        ['keylocker', 'view', yaml_path, '--key-file', generated_key_file], # Нужно добавить поддержку --key-file в CLI
-        capture_output=True, text=True, check=True,
-        # Передаем окружение, чтобы !ENV сработало
-        env={**os.environ, ENV_VAR_NAME: ''} # Гарантируем, что env ключ не установлен
-    )
 
-    assert secret_value in result.stdout
-    assert env_val in result.stdout
-    assert '!SEC' not in result.stdout
-    assert '!ENV' not in result.stdout
+def test_load_yaml_invalid_key_in_file_for_sec_tag_raises_error(yaml_file_factory, unset_env_key, capsys): # <--- НОВЫЙ ТЕСТ
+    """Тест: Загрузка YAML с !SEC и невалидным файлом ключа возбуждает KeylockerConfigError."""
+    invalid_key_file = yaml_file_factory("invalid_for_load.key", "this is not a valid key")
+    yaml_content = """
+    secret: !SEC ABCDEF...
+    """
+    yaml_path = yaml_file_factory("config_bad_key_load.yaml", yaml_content)
 
-# Добавить аналогичный тест для CLI view с ключом из переменной окружения
+    with pytest.raises(KeylockerConfigError) as excinfo: # keylocker_loader оборачивает ошибку ключа в KeylockerConfigError
+        load_yaml_secrets(yaml_path, invalid_key_file)
 
-# === Другие тесты ===
-# - Тест сохранения YAML (потребует создания данных с SecureString/EnvVariable)
-# - Тест невалидного ключа в файле / переменной окружения
-# - Тест невалидного токена !SEC
+    assert "Failed to initialize Fernet cipher due to key error" in str(excinfo.value)
+    assert "Invalid key format in Fernet key file" in str(excinfo.value) # Оригинальная причина
+
+def test_load_main():
+    from fire.core import FireExit
+    try:
+        from keylocker.__main__ import main
+    except FireExit:
+        pass


### PR DESCRIPTION
This commit introduces significant new functionality by adding support for HashiCorp Vault secret fetching and completely refactors the library's error handling mechanisms for improved robustness and clarity. Documentation and tests have been updated accordingly.

Key Changes:

1.  **HashiCorp Vault Integration:**
    * Introduced a new `!VAULT` YAML tag, allowing users to seamlessly fetch secrets directly from HashiCorp Vault within their YAML configuration files.
    * Implemented `vault_constructor` for the YAML loader to process the `!VAULT` tag, handling path and key parsing.
    * Added `_get_vault_client` helper function for robust Vault client initialization, including authentication using `VAULT_TOKEN`.
    * Configuration for Vault access is managed via `VAULT_ADDR` and `VAULT_TOKEN` environment variables.
    * The `hvac` library has been added as a new core dependency for Vault communication.

2.  **Explicit Error Handling with Custom Exceptions:**
    * Core library functions (including `_load_fernet_key`, `_get_vault_client`, `encrypt_string_value`, `load_yaml_secrets`, YAML tag constructors like `sec_constructor` & `vault_constructor`, and `sec_representer` in the dumper) have been refactored.
    * These functions now raise specific, custom exceptions (e.g., `KeylockerFileError`, `KeylockerEncryptionError`, `KeylockerConfigError`, `KeylockerVaultError`, `VaultClientNotInitializedError`, `VaultKeyNotFoundError`, `VaultInvalidPathError`) instead of printing error messages and returning `None` or directly calling `sys.exit()`. This makes the library's error contract clearer and facilitates better error handling by calling code.
    * A bug in `vault_constructor` was fixed where custom exceptions like `VaultKeyNotFoundError` were being incorrectly caught and re-wrapped by a generic `except Exception` block. The `try-except` structure within `vault_constructor` has been refined for correct propagation of specific custom exceptions.

3.  **CLI Enhancements (`Manager` class):**
    * The CLI command methods (`view`, `encrypt`) within the `Manager` class have been updated to catch the newly introduced specific exceptions from the core library functions.
    * These CLI methods now output user-friendly error messages to `stderr` and exit with appropriate non-zero status codes, adhering to standard CLI best practices.

4.  **Testing (`pytest`):**
    * A new suite of `pytest` unit tests (`tests/test_keylocker_vault.py`) has been developed to cover the HashiCorp Vault integration, including various success and failure scenarios.
    * Existing unit tests for Fernet key management, `!SEC` tag processing, and `!ENV` tag resolution (`tests/test_keylocker_yaml.py`) have been updated and refactored to align with the new exception-based error handling paradigm (e.g., using `pytest.raises` to assert specific exceptions).
    * Minor issues in test setup, such as missing imports (e.g., `Fernet` in test files), have been resolved.

5.  **Documentation (`README.md`):**
    * The `README.md` file has been extensively updated to accurately reflect all new features and significant changes.
    * Comprehensive documentation for the HashiCorp Vault integration has been added, including details on the `!VAULT` tag syntax and the required `VAULT_ADDR` and `VAULT_TOKEN` environment variables.
    * Python code usage examples in `README.md` have been revised to demonstrate best practices for `try-except` blocks to handle the new specific `KeylockerError` exceptions.
    * Bash usage examples have also been updated.
    * The entire `README.md` content has been translated into English.

6.  **Dependencies:**
    * `hvac` has been added to `requirements.txt` as a runtime dependency.
    * `pytest` and `pytest-mock` are confirmed as development dependencies for the test suite.