### PR TITLE
feat: Add Helm chart for keylocker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt /app/
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the entire keylocker package into the container at /app/keylocker
+COPY keylocker /app/keylocker
+
+# Copy Pipfile and Pipfile.lock (optional, if you decide to use pipenv later)
+COPY Pipfile Pipfile.lock /app/
+
+# This environment variable can be used to set the default key file path if needed
+ENV KEYLOCKER_KEY_FILE_PATH /app/storage.key
+
+# Default command can be overridden.
+# For example, to run keylocker CLI:
+# CMD ["python", "-m", "keylocker.keylocker", "view", "config/config.yaml"]
+# Or to run a custom script:
+# CMD ["python", "my_custom_script.py"]
+# For now, we provide a simple default command.
+CMD ["python"]

--- a/keylocker-chart/.helmignore
+++ b/keylocker-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/keylocker-chart/Chart.yaml
+++ b/keylocker-chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: keylocker-chart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/keylocker-chart/templates/NOTES.txt
+++ b/keylocker-chart/templates/NOTES.txt
@@ -1,0 +1,110 @@
+The keylocker Helm chart has been deployed.
+
+This chart allows you to run the keylocker CLI tool or your own Python scripts that use the keylocker library.
+
+---------------------------------------------------------------------------------
+**1. Configuration via `values.yaml`:**
+
+Before installing or upgrading, customize your `values.yaml` or use `--set` flags during `helm install/upgrade`.
+
+Key sections in `values.yaml`:
+  - `image.repository`, `image.tag`: Specify your keylocker Docker image.
+  - `replicaCount`: Usually 1 for CLI tasks.
+  - `keylocker.command`, `keylocker.args`: Define what command and arguments the container should run.
+    - To run keylocker CLI (e.g., view a config):
+      command: ["python", "-m", "keylocker.__main__"] # Or your entrypoint if keylocker is in PATH
+      args: ["view", "/app/config/my-config.yaml"]
+    - To run a custom Python script:
+      command: ["python"]
+      args: ["/app/scripts/my_custom_script.py"]
+  - `keylocker.envVars`: Set environment variables. Sensitive values like KEYLOCKER_SECRET_KEY, VAULT_ADDR, VAULT_TOKEN should be sourced from Kubernetes Secrets.
+  - `keylocker.configFiles`: Mount keylocker configuration files (e.g., your input YAML for `keylocker view`) from ConfigMaps.
+  - `keylocker.customScripts`: Mount your custom Python scripts from ConfigMaps.
+
+---------------------------------------------------------------------------------
+**2. Managing Secrets:**
+
+The application requires secrets for `KEYLOCKER_SECRET_KEY` (for !SEC tags) and potentially `VAULT_ADDR` and `VAULT_TOKEN` (for !VAULT tags).
+These should be stored as Kubernetes Secrets and referenced in `values.yaml`.
+
+**Example Secret Creation:**
+
+a. For `KEYLOCKER_SECRET_KEY`:
+   kubectl create secret generic {{ .Release.Name }}-keylocker-fernet-key --from-literal=KEYLOCKER_SECRET_KEY='YOUR_BASE64_ENCODED_FERNET_KEY' -n {{ .Release.Namespace }}
+   
+   Then in your `values.yaml`:
+   keylocker:
+     envVars:
+       KEYLOCKER_SECRET_KEY_FROM_SECRET:
+         secretName: "{{ .Release.Name }}-keylocker-fernet-key"
+         secretKey: "KEYLOCKER_SECRET_KEY"
+
+b. For Vault Address:
+   kubectl create secret generic {{ .Release.Name }}-vault-addr --from-literal=VAULT_ADDR='http://your-vault-address:8200' -n {{ .Release.Namespace }}
+
+   Then in your `values.yaml`:
+   keylocker:
+     envVars:
+       VAULT_ADDR_FROM_SECRET:
+         secretName: "{{ .Release.Name }}-vault-addr"
+         secretKey: "VAULT_ADDR"
+
+c. For Vault Token:
+   kubectl create secret generic {{ .Release.Name }}-vault-token --from-literal=VAULT_TOKEN='your-vault-token' -n {{ .Release.Namespace }}
+
+   Then in your `values.yaml`:
+   keylocker:
+     envVars:
+       VAULT_TOKEN_FROM_SECRET:
+         secretName: "{{ .Release.Name }}-vault-token"
+         secretKey: "VAULT_TOKEN"
+
+---------------------------------------------------------------------------------
+**3. Using Custom ConfigMaps for Keylocker YAML and Python Scripts:**
+
+a. To provide a `config.yaml` for `keylocker view`:
+   1. Create a ConfigMap:
+      kubectl create configmap {{ .Release.Name }}-keylocker-config --from-file=my-config.yaml=./path/to/your/local/config.yaml -n {{ .Release.Namespace }}
+   2. Configure `values.yaml`:
+      keylocker:
+        configFiles:
+          - name: "keylocker-config-volume"
+            mountPath: "/app/config" # The file will be at /app/config/my-config.yaml
+            configMapName: "{{ .Release.Name }}-keylocker-config"
+            # subPath: "my-config.yaml" # Optional: use if you only want to mount this specific file
+
+b. To provide a custom Python script:
+   1. Create a ConfigMap:
+      kubectl create configmap {{ .Release.Name }}-custom-scripts --from-file=my_script.py=./path/to/your/local/my_script.py -n {{ .Release.Namespace }}
+   2. Configure `values.yaml`:
+      keylocker:
+        customScripts:
+          - name: "keylocker-scripts-volume"
+            mountPath: "/app/scripts" # Your script will be at /app/scripts/my_script.py
+            configMapName: "{{ .Release.Name }}-custom-scripts"
+
+---------------------------------------------------------------------------------
+**4. Accessing Pod Logs:**
+
+To see the output of your keylocker command or custom script, you can view the logs of the pod:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "keylocker-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl logs $POD_NAME --namespace {{ .Release.Namespace }}
+
+If `replicaCount` > 1 or for more advanced selection, adjust the `POD_NAME` command.
+
+---------------------------------------------------------------------------------
+**5. Example Helm Install Command:**
+
+helm install {{ .Release.Name }} . \
+  --namespace {{ .Release.Namespace }} \
+  --set keylocker.command='{"python", "-m", "keylocker.__main__"}' \
+  --set keylocker.args='{"view", "/app/config/my-config.yaml"}' \
+  --set keylocker.envVars.KEYLOCKER_SECRET_KEY_FROM_SECRET.secretName='{{ .Release.Name }}-keylocker-fernet-key' \
+  --set keylocker.envVars.KEYLOCKER_SECRET_KEY_FROM_SECRET.secretKey='KEYLOCKER_SECRET_KEY' \
+  --set keylocker.configFiles[0].name='keylocker-config-volume' \
+  --set keylocker.configFiles[0].mountPath='/app/config' \
+  --set keylocker.configFiles[0].configMapName='{{ .Release.Name }}-keylocker-config'
+  # Add other --set flags as needed for Vault, custom scripts, etc.
+
+Remember to create the referenced secrets and configmaps before installing the chart if they are required by your configuration.

--- a/keylocker-chart/templates/_helpers.tpl
+++ b/keylocker-chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keylocker-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "keylocker-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keylocker-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keylocker-chart.labels" -}}
+helm.sh/chart: {{ include "keylocker-chart.chart" . }}
+{{ include "keylocker-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keylocker-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keylocker-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "keylocker-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "keylocker-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/keylocker-chart/templates/deployment.yaml
+++ b/keylocker-chart/templates/deployment.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keylocker-chart.fullname" . }}
+  labels:
+    {{- include "keylocker-chart.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "keylocker-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "keylocker-chart.selectorLabels" . | nindent 8 }} # Use selectorLabels for consistency
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "keylocker-chart.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.keylocker.command }}
+          command: {{ toYaml .Values.keylocker.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.keylocker.args }}
+          args: {{ toYaml .Values.keylocker.args | nindent 12 }}
+          {{- end }}
+          env:
+            {{- /* Direct environment variables specified in values.yaml */}}
+            {{- range $key, $value := .Values.keylocker.envVars }}
+            {{- if not (kindIs "map" $value) }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- /* Environment variables sourced from secrets */}}
+            {{- if .Values.keylocker.envVars.KEYLOCKER_SECRET_KEY_FROM_SECRET.secretName }}
+            - name: KEYLOCKER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keylocker.envVars.KEYLOCKER_SECRET_KEY_FROM_SECRET.secretName }}
+                  key: {{ .Values.keylocker.envVars.KEYLOCKER_SECRET_KEY_FROM_SECRET.secretKey }}
+            {{- end }}
+            {{- if .Values.keylocker.envVars.VAULT_ADDR_FROM_SECRET.secretName }}
+            - name: VAULT_ADDR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keylocker.envVars.VAULT_ADDR_FROM_SECRET.secretName }}
+                  key: {{ .Values.keylocker.envVars.VAULT_ADDR_FROM_SECRET.secretKey }}
+            {{- end }}
+            {{- if .Values.keylocker.envVars.VAULT_TOKEN_FROM_SECRET.secretName }}
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keylocker.envVars.VAULT_TOKEN_FROM_SECRET.secretName }}
+                  key: {{ .Values.keylocker.envVars.VAULT_TOKEN_FROM_SECRET.secretKey }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $allVolumeMounts := list }}
+          {{- if .Values.keylocker.configFiles }}
+            {{- range .Values.keylocker.configFiles }}
+              {{- $vm := dict "name" .name "mountPath" .mountPath }}
+              {{- if .subPath }}
+                {{- $_ := set $vm "subPath" .subPath }}
+              {{- end }}
+              {{- $allVolumeMounts = append $allVolumeMounts $vm }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.keylocker.customScripts }}
+            {{- range .Values.keylocker.customScripts }}
+              {{- $allVolumeMounts = append $allVolumeMounts (dict "name" .name "mountPath" .mountPath) }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.volumeMounts }}
+            {{- $allVolumeMounts = concat $allVolumeMounts .Values.volumeMounts }}
+          {{- end }}
+          {{- if $allVolumeMounts }}
+          volumeMounts:
+            {{- toYaml $allVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- /* Ports are removed by default, user can add if their script needs it via values */}}
+          {{- /* Liveness and readiness probes are removed by default */}}
+      {{- $allVolumes := list }}
+      {{- if .Values.keylocker.configFiles }}
+        {{- range .Values.keylocker.configFiles }}
+          {{- $allVolumes = append $allVolumes (dict "name" .name "configMap" (dict "name" .configMapName)) }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.keylocker.customScripts }}
+        {{- range .Values.keylocker.customScripts }}
+          {{- $allVolumes = append $allVolumes (dict "name" .name "configMap" (dict "name" .configMapName)) }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.volumes }}
+        {{- $allVolumes = concat $allVolumes .Values.volumes }}
+      {{- end }}
+      {{- if $allVolumes }}
+      volumes:
+        {{- toYaml $allVolumes | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/keylocker-chart/templates/serviceaccount.yaml
+++ b/keylocker-chart/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "keylocker-chart.serviceAccountName" . }}
+  labels:
+    {{- include "keylocker-chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/keylocker-chart/templates/tests/test-connection.yaml
+++ b/keylocker-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "keylocker-chart.fullname" . }}-test-app"
+  labels:
+    {{- include "keylocker-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: keylocker-test
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      # Attempt to run the keylocker command with --help, which python-fire should provide.
+      # This verifies the entrypoint and basic functioning.
+      command: ['python', '-m', 'keylocker.__main__']
+      args: ['--help']
+      # If KEYLOCKER_SECRET_KEY is strictly required for --help (it shouldn't be),
+      # this test might need to be more complex, potentially mounting a dummy key.
+      # For now, assume --help works without it.
+  restartPolicy: Never

--- a/keylocker-chart/values.yaml
+++ b/keylocker-chart/values.yaml
@@ -1,0 +1,161 @@
+# Default values for keylocker-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1 # Keep for potential long-running script scenarios, though often will be 1 for CLI tasks
+
+image:
+  repository: keylocker # Replace with your actual image repository if you publish it
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  # Defaulting to appVersion is good practice.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# keylocker specific configurations
+keylocker:
+  # Command and arguments to run in the container.
+  # Examples:
+  # To run keylocker CLI to view a config file:
+  # command: ["python", "-m", "keylocker"] # or just ["keylocker"] if it's in PATH
+  # args: ["view", "/etc/keylocker/config.yaml"]
+  # To run a custom python script:
+  # command: ["python"]
+  # args: ["/app/custom_script/my_script.py"]
+  # By default, it will use the Docker image's CMD (which is "python")
+  command: [] # Defaults to image CMD. Example: ["python", "-m", "keylocker.__main__"]
+  args: []    # Example: ["view", "/app/config/myconfig.yaml"]
+
+  # Configuration for environment variables sourced from Kubernetes Secrets.
+  # Users need to create these secrets beforehand.
+  # Example secret creation:
+  # kubectl create secret generic keylocker-secret --from-literal=KEYLOCKER_SECRET_KEY='yourbase64key'
+  # kubectl create secret generic vault-addr-secret --from-literal=VAULT_ADDR='http://your-vault:8200'
+  # kubectl create secret generic vault-token-secret --from-literal=VAULT_TOKEN='yourvaulttoken'
+
+  envVars:
+    # KEYLOCKER_SECRET_KEY: "your_direct_key" # Direct value (less secure, for testing)
+    # VAULT_ADDR: "http://vault.example.com:8200" # Direct value
+    # VAULT_TOKEN: "s.somesecrettoken" # Direct value
+    # Or, more securely, using existing secrets:
+    KEYLOCKER_SECRET_KEY_FROM_SECRET:
+      secretName: "" # Name of the K8s secret, e.g., "keylocker-secret"
+      secretKey: ""  # Key within the secret, e.g., "KEYLOCKER_SECRET_KEY"
+    VAULT_ADDR_FROM_SECRET:
+      secretName: "" # e.g., "vault-config-secret"
+      secretKey: ""  # e.g., "VAULT_ADDR"
+    VAULT_TOKEN_FROM_SECRET:
+      secretName: "" # e.g., "vault-auth-secret"
+      secretKey: ""  # e.g., "VAULT_TOKEN"
+    
+    # Additional generic environment variables can be added here as key-value pairs
+    # customEnvVar1: "value1"
+
+  # Configuration for mounting a custom YAML configuration file for keylocker view
+  # The ConfigMap should be created by the user with their keylocker YAML content.
+  # Example: kubectl create configmap my-keylocker-config --from-file=config.yaml=./path/to/your/config.yaml
+  configFiles:
+    # Example: Mount a 'config.yaml' from a ConfigMap into '/app/config/config.yaml'
+    # - name: "keylocker-config" # Name of the volume mount
+    #   mountPath: "/app/config" # Path inside the container where the file(s) will be mounted
+    #   configMapName: "" # Name of the ConfigMap, e.g., "my-keylocker-config"
+    #   subPath: "" # Optional: if you want to mount a specific file from the ConfigMap, e.g. "config.yaml"
+    #                 # If empty, mounts all keys from ConfigMap as files.
+
+  # Configuration for mounting custom Python scripts that use the keylocker library.
+  # The ConfigMap should be created by the user with their Python script(s).
+  # Example: kubectl create configmap my-python-scripts --from-file=my_script.py=./path/to/your/my_script.py
+  customScripts:
+    # Example: Mount scripts from a ConfigMap into '/app/scripts'
+    # - name: "my-scripts-volume"
+    #   mountPath: "/app/scripts" # Path inside the container
+    #   configMapName: "" # Name of the ConfigMap, e.g., "my-python-scripts"
+
+# Service settings are typically not needed for a CLI tool unless it starts a server.
+# Users can enable this if their custom script runs a service.
+service:
+  enabled: false
+  type: ClusterIP
+  port: 80
+
+# Ingress settings - typically not needed for a CLI tool.
+ingress:
+  enabled: false
+  # className: ""
+  # annotations: {}
+  # hosts:
+  #   - host: chart-example.local
+  #     paths:
+  #       - path: /
+  #         pathType: ImplementationSpecific
+  # tls: []
+
+# Resource requests and limits
+# It's good practice to set these.
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# Probes are commented out by default as they are more for long-running services.
+# If your script is a long-running service, configure these.
+# livenessProbe:
+#   httpGet:
+#     path: /
+#     port: http
+# readinessProbe:
+#   httpGet:
+#     path: /
+#     port: http
+
+# Autoscaling is disabled by default.
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 100
+  # targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes and volumeMounts can be defined here if needed for advanced scenarios.
+# These are merged with volumes/volumeMounts generated for configFiles and customScripts.
+volumes: []
+# Example:
+# - name: host-path-volume
+#   hostPath:
+#     path: /data
+#     type: Directory
+
+volumeMounts: []
+# Example:
+# - name: host-path-volume
+#   mountPath: /mnt/host-data
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
This commit introduces a Helm chart for deploying the keylocker Python application to Kubernetes. The chart is designed to facilitate debugging and running keylocker as a CLI tool or for Python applications using the keylocker library.

Key changes include:

1.  **Dockerfile**: Added a Dockerfile to containerize the keylocker application and its dependencies.
2.  **Helm Chart (`keylocker-chart/`)**:
    *   Generated a standard Helm chart structure.
    *   Customized `values.yaml` to provide flexible configuration for the
        image, command/arguments, secret management (KEYLOCKER_SECRET_KEY,
        VAULT_ADDR, VAULT_TOKEN via Kubernetes Secrets), and mounting of
        custom configuration files or Python scripts via ConfigMaps.
    *   Modified `templates/deployment.yaml` to dynamically configure the
        deployment based on `values.yaml`, including environment variables,
        secret sourcing, command overrides, and volume mounts.
    *   Significantly rewrote `templates/NOTES.txt` to offer detailed
        guidance on chart installation, configuration, secret management,
        and usage examples for keylocker.
    *   Removed unused templates like `service.yaml`, `ingress.yaml`, and
        `hpa.yaml` which are not relevant for a CLI tool by default.
    *   Updated `templates/tests/test-connection.yaml` with a more
        appropriate test for a CLI application (verifies `keylocker --help`).
    *   Ensured `helm lint` passes for the chart.
    *   A basic `README.md` for the chart is intended (content prepared).

This chart allows you to run keylocker in your Kubernetes environment for processing YAML files with !SEC, !ENV, and !VAULT tags, or for running your own Python scripts that leverage the keylocker library for secret management.