### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,6 +2,9 @@
 
 name: Build, Test, and Publish Python Package (Pipenv)
 
+permissions:
+  contents: read
+
 # Триггеры запуска:
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vpuhoff/keylocker/security/code-scanning/2](https://github.com/vpuhoff/keylocker/security/code-scanning/2)

The fix is to add a `permissions` block with the minimum required privileges. For Python package build and publish workflows, most steps (checkout, setup-python, etc.) require only `contents: read` permission. If no step in the workflow requires write access to the repository, this can be applied at the workflow root, so it will apply to both jobs (`build_and_test` and `deploy`). No step in these jobs appears to create releases or modify anything in the repository itself. Thus, adding `permissions: contents: read` near the top (after the `name:` and before or after `on:`) is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a workflow-level `permissions: contents: read` to `.github/workflows/python-publish.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cff42303ab992d228503b400e2363d231994225a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->